### PR TITLE
Mr 26 covariate tabs

### DIFF
--- a/R/bayes_analysis.R
+++ b/R/bayes_analysis.R
@@ -12,6 +12,7 @@
 #'  - 'ntx' = Number of treatments
 #'  - 'treat_list2' = Same as @param treat_list (TM: Not sure why this is here)
 #'  - 'mtcRelEffects' = Output from gemtc::relative.effect
+#'  - 'rel_eff_tbl = Output from gemtc::relative.effect.table
 #'  - 'sumresults' = summary(mtcRelEffects)
 #'  - 'a' = "fixed effect" or "random effect"
 #'  - 'mtcNetwork' = Output from gemtc::mtc.network
@@ -55,6 +56,7 @@ baye <- function(data,treat_list, model, outcome, CONBI, ref) {
     mtcResults <- mtc.run(mtcModel)   # Run gemtc model object for analysis
     progress$inc(0.4, detail="Rendering results")
     mtcRelEffects <- relative.effect(mtcResults,t1=ref)  #Set reference treatment
+    rel_eff_tbl <- relative.effect.table(mtcResults) 
     #mtcRelEffects <- relative.effect(mtcResults,t1=treat_list2[1,2])  #Set reference treatment
     sumresults<-summary(mtcRelEffects)
     a<- paste(model,"effect",sep=" ")   #Create text for random/fixed effect
@@ -64,7 +66,7 @@ baye <- function(data,treat_list, model, outcome, CONBI, ref) {
     sumoverall<-summary(mtcResults)
     dic<-as.data.frame(sumoverall$DIC) # The statistics 'Dbar', 'pD', 'DIC', and 'data points'
     list(mtcResults=mtcResults,lstx=lstx,ntx=ntx,treat_list2=treat_list2,mtcRelEffects=mtcRelEffects,
-         sumresults=sumresults, a=a, mtcNetwork=mtcNetwork, dic=dic, model=model, outcome=outcome)
+         rel_eff_tbl=rel_eff_tbl, sumresults=sumresults, a=a, mtcNetwork=mtcNetwork, dic=dic, model=model, outcome=outcome)
   }}
 
 

--- a/R/bayes_analysis.R
+++ b/R/bayes_analysis.R
@@ -120,6 +120,7 @@ CreateTauSentence <- function(results,outcome) {
 #' @param rankdirection "good" or "bad" (referring to smaller outcome values).
 #' @param longdata Output from 'dataform.df' function. This should be the same dataset that was passed as the 'data' argument to baye(), which resulted in @param NMAdata.
 #'        (TM: Suggested improvement: baye() should output its 'data' argument, then @param longdata becomes superfluous, and there is no possibility of a mismatch between @param NMAdata and @param longdata.)
+#' @param cov_value covariate value if a meta-regression
 #' @return List:
 #' - 'SUCRA' = Data frame of SUCRA data.
 #'     - 'Treatment'
@@ -141,13 +142,15 @@ CreateTauSentence <- function(results,outcome) {
 #'     - ...
 #'     - 'Rank n_t' = Probability 'Treatment' is ranked last (n_t = number of treatments).
 #' - 'BUGSnetData' = Output from BUGSnet::data.prep with arguments from @param longdata.
-rankdata <- function(NMAdata, rankdirection, longdata) {
+rankdata <- function(NMAdata, rankdirection, longdata, cov_value = NA) {
   # data frame of colours
   colour_dat = data.frame(SUCRA = seq(0, 100, by = 0.1)) 
   colour_dat = dplyr::mutate(colour_dat, colour = seq(0, 100, length.out = 1001)) 
   
   # probability rankings
-  prob <- as.data.frame(print(gemtc::rank.probability(NMAdata, preferredDirection=(if (rankdirection=="good") -1 else 1)))) # rows treatments, columns ranks
+  prob <- as.data.frame(print(gemtc::rank.probability(NMAdata, 
+                                                      preferredDirection=(if (rankdirection=="good") -1 else 1), 
+                                                      covariate = cov_value))) # rows treatments, columns ranks
   names(prob)[1:ncol(prob)] <- paste("Rank ", 1:(ncol(prob)), sep="")
   sucra <- gemtc::sucra(prob)  # 1 row of SUCRA values for each treatment column
   treatments <- stringr::str_wrap(gsub("_", " ", row.names(prob)), width=10)

--- a/R/bayesian/forest_plot_plus_stats.R
+++ b/R/bayesian/forest_plot_plus_stats.R
@@ -80,6 +80,9 @@ bayesian_forest_plot_plus_stats_server <- function(
                   Bayesian",
                   model_output()$a, 
                   "consistency model forest plot results"))
+      if (analysis_type == "Regression") {
+        mtext(model_output()$cov_value_sentence, side = 1, adj = 0)
+      }
     })
 
     # DIC table for all studies

--- a/R/bayesian/ranking/ranking_forest_panel.R
+++ b/R/bayesian/ranking/ranking_forest_panel.R
@@ -63,7 +63,7 @@ ranking_forest_panel_server <- function(
 
     output$download_rank_forest <- downloadHandler(
       filename = function() {
-        paste0(filename_prefix, ".Forest", input$rank_forest_choice)
+        paste0(filename_prefix, "Forest.", input$rank_forest_choice)
       },
       content = function(file) {
         draw_forest <- function() {

--- a/R/bayesian/ranking/ranking_forest_panel.R
+++ b/R/bayesian/ranking/ranking_forest_panel.R
@@ -34,7 +34,7 @@ ranking_forest_panel_ui <- function(id) {
 #' @param frequentist_react Reactive containing frequentist meta-analysis
 #' @param bugsnetdt_react Reactive containing bugsnet meta-analysis
 #' @param filename_prefix Prefix to add before file names.
-#' @param title_prefix Prefix to add beofre plot titles.
+#' @param title_prefix Prefix to add before plot titles.
 ranking_forest_panel_server <- function(
     id,
     model,
@@ -63,12 +63,15 @@ ranking_forest_panel_server <- function(
 
     output$download_rank_forest <- downloadHandler(
       filename = function() {
-        paste0(filename_prefix, ".", input$rank_forest_choice)
+        paste0(filename_prefix, ".Forest", input$rank_forest_choice)
       },
       content = function(file) {
         draw_forest <- function() {
           gemtc::forest(model()$mtcRelEffects, digits = 3)
           title(paste0(title_prefix, ": Bayesian ", model()$a, " consistency model forest plot results"), cex.main = 0.85)
+          if (model()$mtcResults$model$type == 'regression') {
+            mtext(model()$cov_value_sentence, side = 1, adj = 0)
+          }
         }
         write_to_pdf_or_png(
           file,

--- a/R/bayesian/ranking/ranking_panel.R
+++ b/R/bayesian/ranking/ranking_panel.R
@@ -43,6 +43,7 @@ ranking_panel_ui <- function(id, title, table_label) {
 #' @param rank_option Reactive containing ranking option: "good" or "bad" depending on whether small values are desirable or not
 #' @param frequentist Reactive containing frequentist meta-analysis
 #' @param bugsnetdt Reactive containing bugsnet meta-analysis
+#' @param cov_value Value of covariate for regression analysis
 #' @param exclusions Reactive containing names of studies excluded from the sensitivity analysis
 ranking_panel_server <- function(
     id,
@@ -55,12 +56,14 @@ ranking_panel_server <- function(
     bugsnetdt,
     filename_prefix,
     title_prefix,
+    cov_value = reactive({NA}),
     exclusions = reactive({ c() })
     ) {
   moduleServer(id, function(input, output, session) {
     
     ranking_data <- eventReactive(model(), {
-      obtain_rank_data(data(), metaoutcome(), treatment_df(), model(), rank_option(), exclusions())
+      r_data <- obtain_rank_data(data(), metaoutcome(), treatment_df(), model(), rank_option(), cov_value(), exclusions())
+      return(r_data)
     })
 
     # Network plots for ranking panel (Bayesian) (they have slightly different formatting to those on tab1) CRN
@@ -87,10 +90,19 @@ ranking_panel_server <- function(
       title_prefix = title_prefix
     )
     
+    regression_text <- reactive({
+      if (is.na(cov_value()) == FALSE) {
+        return(model()$cov_value_sentence)
+      } else {
+        return("")
+      }
+    })
+    
     rankogram_panel_server(
       id = "rankogram",
       ranking_data = ranking_data,
-      filename_prefix = filename_prefix
+      filename_prefix = filename_prefix,
+      regression_text = regression_text
     )
     
     ranking_network_panel_server(

--- a/R/bayesian/ranking/rankogram_panel.R
+++ b/R/bayesian/ranking/rankogram_panel.R
@@ -90,20 +90,22 @@ rankogram_panel_ui <- function(id, table_label) {
 #' @param id ID of the module.
 #' @param ranking_data Reactive containing ranking data.
 #' @param filename_prefix Prefix to add before file names.
+#' @param regression_text Regression annotation if needed
 rankogram_panel_server <- function(
     id,
     ranking_data,
-    filename_prefix
+    filename_prefix,
+    regression_text
     ) {
   moduleServer(id, function(input, output, session) {
 
     # All rank plots in one function for easier loading when switching options #
     Rankplots <- reactive({
       plots <- list()
-      plots$Litmus <- LitmusRankOGram(CumData = ranking_data()$Cumulative, SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, colourblind = FALSE)
-      plots$Radial <- RadialSUCRA(SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, BUGSnetData = ranking_data()$BUGSnetData, colourblind = FALSE)
-      plots$Litmus_blind <- LitmusRankOGram(CumData = ranking_data()$Cumulative, SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, colourblind = TRUE)
-      plots$Radial_blind <- RadialSUCRA(SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, BUGSnetData = ranking_data()$BUGSnetData, colourblind = TRUE)
+      plots$Litmus <- LitmusRankOGram(CumData = ranking_data()$Cumulative, SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, colourblind = FALSE, regression_text = regression_text())
+      plots$Radial <- RadialSUCRA(SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, BUGSnetData = ranking_data()$BUGSnetData, colourblind = FALSE, regression_text = regression_text())
+      plots$Litmus_blind <- LitmusRankOGram(CumData = ranking_data()$Cumulative, SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, colourblind = TRUE, regression_text = regression_text())
+      plots$Radial_blind <- RadialSUCRA(SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, BUGSnetData = ranking_data()$BUGSnetData, colourblind = TRUE, regression_text = regression_text())
       return(plots)
     })
 

--- a/R/bayesian/treatment_comparison_page.R
+++ b/R/bayesian/treatment_comparison_page.R
@@ -33,13 +33,11 @@ bayesian_treatment_comparisons_page_ui <- function(id) {
 #' @param id ID of the module
 #' @param model Reactive containing bayesian meta-analysis for all studies
 #' @param model_sub Reactive containing meta-analysis with studies excluded
-#' @param metaoutcome Reactive containing meta analysis outcome: "Continuous" or "Binary"
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD", "SMD", "OR, "RR", or "RD"
 bayesian_treatment_comparisons_page_server <- function(
     id,
     model,
     model_sub,
-    metaoutcome,
     outcome_measure
     ) {
   moduleServer(id, function(input, output, session) {
@@ -47,27 +45,27 @@ bayesian_treatment_comparisons_page_server <- function(
 
     # Treatment effects for all studies
     output$baye_comparison <- renderTable ({
-      baye_comp(model(), metaoutcome(), outcome_measure())
+      baye_comp(model(), outcome_measure())
     }, rownames=TRUE, colnames = TRUE
     )
 
     # Treatment effects with studies excluded
     output$baye_comparison_sub <- renderTable ({
-      baye_comp(model_sub(), metaoutcome(), outcome_measure())
+      baye_comp(model_sub(), outcome_measure())
     }, rownames=TRUE, colnames = TRUE
     )
 
     output$downloadbaye_comparison <- downloadHandler(
       filename = 'baye_comparison.csv',
       content = function(file) {
-        write.csv(baye_comp(model(), metaoutcome(), outcome_measure()), file)
+        write.csv(baye_comp(model(), outcome_measure()), file)
       }
     )
 
     output$downloadbaye_comparison_sub <- downloadHandler(
       filename = 'baye_comparison_sub.csv',
       content = function(file) {
-        write.csv(baye_comp(model_sub(), metaoutcome(), outcome_measure()), file)
+        write.csv(baye_comp(model_sub(), outcome_measure()), file)
       }
     )
   })

--- a/R/bayesian_analysis_panel.R
+++ b/R/bayesian_analysis_panel.R
@@ -111,7 +111,6 @@ bayesian_analysis_panel_server <- function(
       id = "treatment_comparisons",
       model = model,
       model_sub = model_sub,
-      metaoutcome = metaoutcome,
       outcome_measure = outcome_measure
     )
 

--- a/R/covariate_analysis_panel.R
+++ b/R/covariate_analysis_panel.R
@@ -67,6 +67,10 @@ covariate_analysis_panel_ui <- function(id) {
               align = "center",
               bayesian_forest_plot_plus_stats_ui(id = ns("cov_forest_plots"))
             )
+          ),
+          tabPanel(
+            title = "4c-2. Comparison of all treatment pairs",
+            covariate_treatment_comparisons_page_ui(id = ns("cov_treatment_comparisons"))
           )
         )
       )
@@ -161,8 +165,10 @@ covariate_analysis_panel_server <- function(
       covariate_type = reactive({ input$covariate_type_selection }),
       covariate_data = reactive({ all_data()[[covariate_title()]] })
     )
+    
     # obtain gemtc output types to be used in rest of page
     model_output <- reactive(CovariateModelOutput(model = model_reactive(), cov_value = covariate_value()))
+    
     # Create forest plot and associated statistics
     bayesian_forest_plot_plus_stats_server(
       id = "cov_forest_plots",
@@ -171,6 +177,13 @@ covariate_analysis_panel_server <- function(
       metaoutcome = metaoutcome,
       outcome_measure = outcome_measure,
       bugsnetdt = bugsnetdt
+    )
+    
+    # 4c-2 Treatment comparisons
+    covariate_treatment_comparisons_page_server(
+      id = "cov_treatment_comparisons",
+      model = model_output,
+      outcome_measure = outcome_measure
     )
   })
 }

--- a/R/covariate_analysis_panel.R
+++ b/R/covariate_analysis_panel.R
@@ -71,6 +71,10 @@ covariate_analysis_panel_ui <- function(id) {
           tabPanel(
             title = "4c-2. Comparison of all treatment pairs",
             covariate_treatment_comparisons_page_ui(id = ns("cov_treatment_comparisons"))
+          ),
+          tabPanel(
+            title = "4c-3. Ranking",
+            covariate_ranking_page_ui(id = ns("cov_ranking"))
           )
         )
       )
@@ -86,6 +90,8 @@ covariate_analysis_panel_ui <- function(id) {
 #' @param metaoutcome Reactive containing meta analysis outcome: "Continuous" or "Binary"
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD", "SMD", "OR, "RR", or "RD"
 #' @param model_effects Reactive containing model effects: either "random" or "fixed"
+#' @param rank_option Reactive containing ranking option: "good" or "bad" depending on whether small values are desirable or not
+#' @param freq_all Reactive containing frequentist meta-analysis
 #' @param bugsnetdt Reactive containing bugsnet meta-analysis
 covariate_analysis_panel_server <- function(
     id, 
@@ -94,6 +100,8 @@ covariate_analysis_panel_server <- function(
     metaoutcome,
     outcome_measure,
     model_effects,
+    rank_option,
+    freq_all,
     bugsnetdt
     ) {
   shiny::moduleServer(id, function(input, output, session) {
@@ -167,7 +175,10 @@ covariate_analysis_panel_server <- function(
     )
     
     # obtain gemtc output types to be used in rest of page
-    model_output <- reactive(CovariateModelOutput(model = model_reactive(), cov_value = covariate_value()))
+    model_output <- reactive({
+      m_output <- CovariateModelOutput(model = model_reactive(), cov_value = covariate_value())
+      return(m_output)
+      })
     
     # Create forest plot and associated statistics
     bayesian_forest_plot_plus_stats_server(
@@ -184,6 +195,21 @@ covariate_analysis_panel_server <- function(
       id = "cov_treatment_comparisons",
       model = model_output,
       outcome_measure = outcome_measure
+    )
+    
+    # 4c-3 Ranking Panel
+    covariate_ranking_page_server(
+      id = "cov_ranking",
+      model = model_output,
+      data = all_data,
+      treatment_df = treatment_df,
+      metaoutcome = metaoutcome,
+      outcome_measure = outcome_measure,
+      model_effects = model_effects,
+      rank_option = rank_option,
+      freq_all = freq_all,
+      bugsnetdt = bugsnetdt,
+      cov_value = covariate_value
     )
   })
 }

--- a/R/data_analysis_page.R
+++ b/R/data_analysis_page.R
@@ -236,6 +236,8 @@ data_analysis_page_server <- function(id, data, is_default_data, treatment_df, m
       metaoutcome = metaoutcome,
       outcome_measure = outcome_measure,
       model_effects = model_effects,
+      rank_option = rank_option,
+      freq_all = freq_all,
       bugsnetdt = bugsnetdt
     )
   })

--- a/R/gemtc_analysis.R
+++ b/R/gemtc_analysis.R
@@ -140,7 +140,7 @@ CovariateModelOutput <- function(model, cov_value) {
   summary <- summary(rel_eff)
   
   # Intercepts (regression)
-  intercepts <- summary$summaries$statistics[1:(nrow(model$model$network$treatments)-1),1]
+  intercepts <- summary$summaries$statistics[startsWith(rownames(summary$summaries$statistics), "d."),"Mean"]
   
   # Table of Model fit stats
   fit_stats <- as.data.frame(summary$DIC)
@@ -151,7 +151,7 @@ CovariateModelOutput <- function(model, cov_value) {
   # Obtain slope(s)
   slope_indices <- grep(ifelse(model$model$regressor$coefficient == "shared", "^B$", "^beta\\[[0-9]+\\]$"), model$model$monitors$enabled)
   summ <- summary(model)
-  slopes <- summ$summaries$statistics[slope_indices, 1]  / model$model$regressor$scale
+  slopes <- summ$summaries$statistics[slope_indices, "Mean"]  / model$model$regressor$scale
   
   # Rename rows for intercepts and slopes
   if (model$model$regressor$coefficient != "shared") {

--- a/R/gemtc_analysis.R
+++ b/R/gemtc_analysis.R
@@ -140,7 +140,7 @@ CovariateModelOutput <- function(model, cov_value) {
   summary <- summary(rel_eff)
   
   # Intercepts (regression)
-  intercepts <- summary$summaries$statistics[startsWith(rownames(summary$summaries$statistics), "d."),"Mean"]
+  intercepts <- summary$summaries$quantiles[startsWith(rownames(summary$summaries$quantiles), "d."),"50%"]
   
   # Table of Model fit stats
   fit_stats <- as.data.frame(summary$DIC)
@@ -151,7 +151,7 @@ CovariateModelOutput <- function(model, cov_value) {
   # Obtain slope(s)
   slope_indices <- grep(ifelse(model$model$regressor$coefficient == "shared", "^B$", "^beta\\[[0-9]+\\]$"), model$model$monitors$enabled)
   summ <- summary(model)
-  slopes <- summ$summaries$statistics[slope_indices, "Mean"]  / model$model$regressor$scale
+  slopes <- summ$summaries$quantiles[slope_indices, "50%"]  / model$model$regressor$scale
   
   # Rename rows for intercepts and slopes
   if (model$model$regressor$coefficient != "shared") {

--- a/R/gemtc_analysis.R
+++ b/R/gemtc_analysis.R
@@ -117,6 +117,7 @@ RunCovariateModel <- function(data, treatment_ids, outcome_type, outcome, covari
 #' @param cov_value Value of covariate for which to give output (default value the mean of study covariates)
 #' @return List of gemtc related output:
 #'  mtcRelEffects = data relating to presenting relative effects;
+#'  rel_eff_tbl = table of relative effects for each comparison;
 #'  a = text output stating whether fixed or random effects;
 #'  sumresults = summary output of relative effects
 #'  dic = data frame of model fit statistics
@@ -125,6 +126,9 @@ CovariateModelOutput <- function(model, cov_value) {
   
   # Relative Effects raw data
   rel_eff <- gemtc::relative.effect(model, as.character(model$model$regressor$control), covariate = cov_value)
+  
+  # Relative Effects table of all comparisons
+  rel_eff_tbl <- gemtc::relative.effect.table(model, covariate = cov_value)
   
   # Create text for random/fixed effect
   model_text <- paste(model$model$linearModel,"effect",sep=" ")
@@ -141,6 +145,7 @@ CovariateModelOutput <- function(model, cov_value) {
   # naming conventions to match current Bayesian functions
   return(list(
     mtcRelEffects = rel_eff,
+    rel_eff_tbl = rel_eff_tbl,
     a = model_text,
     sumresults = summary,
     dic = fit_stats,

--- a/R/gemtc_analysis.R
+++ b/R/gemtc_analysis.R
@@ -140,7 +140,7 @@ CovariateModelOutput <- function(model, cov_value) {
   summary <- summary(rel_eff)
   
   # Intercepts (regression)
-  intercepts <- summary$summaries$statistics[1:(nrow(summary$summaries$statistics)-1),1]
+  intercepts <- summary$summaries$statistics[1:(nrow(model$model$network$treatments)-1),1]
   
   # Table of Model fit stats
   fit_stats <- as.data.frame(summary$DIC)
@@ -151,7 +151,7 @@ CovariateModelOutput <- function(model, cov_value) {
   # Obtain slope(s)
   slope_indices <- grep(ifelse(model$model$regressor$coefficient == "shared", "^B$", "^beta\\[[0-9]+\\]$"), model$model$monitors$enabled)
   summ <- summary(model)
-  slopes <- summ$summaries$statistics[slope_indices, 1]  * model$model$regressor$scale
+  slopes <- summ$summaries$statistics[slope_indices, 1]  / model$model$regressor$scale
   
   # Rename rows for intercepts and slopes
   if (model$model$regressor$coefficient != "shared") {

--- a/R/meta_regression/cov_ranking_page.R
+++ b/R/meta_regression/cov_ranking_page.R
@@ -1,0 +1,76 @@
+
+#' Module UI for the covariate ranking page.
+#' 
+#' @param id ID of the module.
+#' @return Div for the page.
+covariate_ranking_page_ui <- function(id) {
+  ns <- NS(id)
+  div(
+    helpText(
+      "Please note: if you change the selections on the sidebar,
+      you will need to re-run the primary and/or sensitivity analysis from the 'Forest Plot' page.",
+      tags$br(),
+      tags$strong("Please note it may take up to 5 minutes to load the results.", style = "color:#FF0000"),
+      tags$br(),
+      tags$strong(
+        "IMPORTANT: If you export and include the Litmus Rank-O-Gram or the Radial SUCRA plot in your work, please cite it as:",
+        style = "color:#4863A0"
+      ),
+      tags$a(
+        href = "https://doi.org/10.1016/j.jclinepi.2023.02.016",
+        "Nevill CR, Cooper NJ, Sutton AJ, A multifaceted graphical display, including treatment ranking, was developed to aid interpretation of network meta-analysis,
+        Journal of Clinical Epidemiology (2023)"
+      )
+    ),
+    fluidRow(
+      ranking_panel_ui(id = ns("rank_all"), title = "Ranking panel for all studies", table_label = "Ranking probabilities and SUCRA values for all treatments")
+    )
+  )
+}
+
+
+#' Module server for the covariate ranking page.
+#' 
+#' @param id ID of the module.
+#' @param model Reactive containing bayesian meta-analysis for all studies.
+#' @param data Reactive containing data to analyse.
+#' @param treatment_df Reactive containing data frame containing treatment IDs (Number) and names (Label).
+#' @param metaoutcome Reactive containing meta analysis outcome: "Continuous" or "Binary".
+#' @param outcome_measure Reactive containing meta analysis outcome measure: "MD", "SMD", "OR, "RR", or "RD".
+#' @param model_effects Reactive containing model effects: either "random" or "fixed".
+#' @param rank_option Reactive containing ranking option: "good" or "bad" depending on whether small values are desirable or not.
+#' @param freq_all Reactive containing frequentist meta-analysis.
+#' @param bugsnetdt Reactive containing bugsnet meta-analysis.
+#' @param cov_value Value of covariate for regression analysis.
+#' regression_text Annotation text for regression model plots.
+covariate_ranking_page_server <- function(
+    id,
+    model,
+    data,
+    treatment_df,
+    metaoutcome,
+    outcome_measure,
+    model_effects,
+    rank_option,
+    freq_all,
+    bugsnetdt,
+    cov_value
+    ) {
+  
+  moduleServer(id, function(input, output, session) {
+    ranking_panel_server(
+      id = "rank_all",
+      data = data,
+      treatment_df = treatment_df,
+      model = model,
+      metaoutcome = metaoutcome,
+      rank_option = rank_option,
+      frequentist = freq_all,
+      bugsnetdt = bugsnetdt,
+      filename_prefix = "regression_",
+      title_prefix = "Regression analysis",
+      cov_value = cov_value
+    )
+    
+  })
+}

--- a/R/meta_regression/treatment_comparison_page.R
+++ b/R/meta_regression/treatment_comparison_page.R
@@ -17,6 +17,7 @@ covariate_treatment_comparisons_page_ui <- function(id) {
     br(),
     p(tags$strong("Treatment effects for all studies: comparison of all treatment pairs.")),
     tableOutput(outputId = ns("baye_comparison")),
+    textOutput(outputId = ns('cov_value_statement')),
     downloadButton(outputId = ns('downloadbaye_comparison'))
   )
 }
@@ -40,6 +41,10 @@ covariate_treatment_comparisons_page_server <- function(
       baye_comp(model(), outcome_measure())
     }, rownames=TRUE, colnames = TRUE
     )
+    
+    output$cov_value_statement <- renderText({
+      model()$cov_value_sentence
+    })
 
     output$downloadbaye_comparison <- downloadHandler(
       filename = 'regression_comparison.csv',

--- a/R/meta_regression/treatment_comparison_page.R
+++ b/R/meta_regression/treatment_comparison_page.R
@@ -1,0 +1,51 @@
+
+#' Module UI for the covariate regression treatment comparisons page.
+#' 
+#' @param id ID of the module.
+#' @return Div for the page.
+covariate_treatment_comparisons_page_ui <- function(id) {
+  ns <- NS(id)
+  div(
+    helpText("Please note: if you change the selections on the sidebar, you will need to re-run the analysis from the 'Forest Plot' page."),
+    p(
+      tags$strong(
+        "This table only contains the estimates from the network meta analysis,
+        i.e. does not contain estimates from pairwise meta-analysis which only contains direct evidence.
+        If you would like to obtain the pairwise meta-analysis results, please run 4c-4. Nodesplit model"
+      )
+    ),
+    br(),
+    p(tags$strong("Treatment effects for all studies: comparison of all treatment pairs.")),
+    tableOutput(outputId = ns("baye_comparison")),
+    downloadButton(outputId = ns('downloadbaye_comparison'))
+  )
+}
+
+
+#' Module server for the covariate regression treatment comparisons page.
+#' 
+#' @param id ID of the module
+#' @param model Reactive containing covariate regression meta-analysis for all studies
+#' @param outcome_measure Reactive containing meta analysis outcome measure: "MD", "SMD", "OR, "RR", or "RD"
+covariate_treatment_comparisons_page_server <- function(
+    id,
+    model,
+    outcome_measure
+    ) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    # Treatment effects for all studies
+    output$baye_comparison <- renderTable ({
+      baye_comp(model(), outcome_measure())
+    }, rownames=TRUE, colnames = TRUE
+    )
+
+    output$downloadbaye_comparison <- downloadHandler(
+      filename = 'regression_comparison.csv',
+      content = function(file) {
+        write.csv(baye_comp(model(), outcome_measure()), file)
+      }
+    )
+  })
+}

--- a/R/meta_regression_tab.R
+++ b/R/meta_regression_tab.R
@@ -75,6 +75,8 @@ meta_regression_tab_ui <- function(id) {
 #' @param metaoutcome Reactive containing meta analysis outcome: "Continuous" or "Binary"
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD", "SMD", "OR, "RR", or "RD"
 #' @param model_effects Reactive containing model effects: either "random" or "fixed"
+#' @param rank_option Reactive containing ranking option: "good" or "bad" depending on whether small values are desirable or not
+#' @param freq_all Reactive containing frequentist meta-analysis
 #' @param bugsnetdt Reactive containing bugsnet meta-analysis
 meta_regression_tab_server <- function(
     id, 
@@ -83,6 +85,8 @@ meta_regression_tab_server <- function(
     metaoutcome,
     outcome_measure,
     model_effects,
+    rank_option,
+    freq_all,
     bugsnetdt
     ) {
   shiny::moduleServer(id, function(input, output, session) {
@@ -123,6 +127,8 @@ meta_regression_tab_server <- function(
               metaoutcome = metaoutcome,
               outcome_measure = outcome_measure,
               model_effects = model_effects,
+              rank_option = rank_option,
+              freq_all = freq_all,
               bugsnetdt = bugsnetdt
             )
           }

--- a/R/plot.R
+++ b/R/plot.R
@@ -98,7 +98,7 @@ make_netgraph_rank = function(freq, order) {
 }
 
 # Litmus Rank-O-Gram #
-LitmusRankOGram <- function(CumData, SUCRAData, ColourData, colourblind=FALSE) {    #CumData needs Treatment, Rank, Cumulative_Probability and SUCRA; SUCRAData needs Treatment & SUCRA; COlourData needs SUCRA & colour; colourblind friendly option
+LitmusRankOGram <- function(CumData, SUCRAData, ColourData, colourblind=FALSE, regression_text="") {    #CumData needs Treatment, Rank, Cumulative_Probability and SUCRA; SUCRAData needs Treatment & SUCRA; COlourData needs SUCRA & colour; colourblind friendly option; regression annotation text
   # Basic Rankogram #
   Rankogram <- ggplot(CumData, aes(x=Rank, y=Cumulative_Probability, group=Treatment)) +
     geom_line(aes(colour=SUCRA)) + theme_classic() + theme(legend.position = "none", aspect.ratio=1) +
@@ -127,12 +127,16 @@ LitmusRankOGram <- function(CumData, SUCRAData, ColourData, colourblind=FALSE) {
     B <- Litmus_SUCRA + scale_colour_gradientn(colours=c("#7b3294","#c2a5cf","#a6dba0", "#008837"), values=c(0, 0.33, 0.66, 1), limits=c(0,100))
   }
   # Combo! #
-  Combo <- A + B    # '+' functionality from {patchwork}
+  if (regression_text != "") {
+    Combo <- A + B + patchwork::plot_annotation(caption = regression_text)
+  } else {
+    Combo <- A + B    # '+' functionality from {patchwork}
+  }
   Combo + theme(plot.margin = margin(t=0,r=0,b=0,l=0))
 }
 
 # Radial SUCRA Plot #
-RadialSUCRA <- function(SUCRAData, ColourData, BUGSnetData, colourblind=FALSE) {      # SUCRAData needs Treatment & Rank; ColourData needs SUCRA & colour; colourblind friendly option
+RadialSUCRA <- function(SUCRAData, ColourData, BUGSnetData, colourblind=FALSE, regression_text="") {      # SUCRAData needs Treatment & Rank; ColourData needs SUCRA & colour; colourblind friendly option; regression annotation text
   
   n <- nrow(SUCRAData) # number of treatments
   # Add values to angle and adjust radial treatment labels
@@ -271,6 +275,10 @@ RadialSUCRA <- function(SUCRAData, ColourData, BUGSnetData, colourblind=FALSE) {
   Final <- magick::image_composite(Final,Points)
   Finalplot <- cowplot::ggdraw() +
     cowplot::draw_image(Final)
+  if (regression_text != "") {
+    Finalplot <- Finalplot + 
+      cowplot::draw_label(regression_text, x = 0.95, y = 0.05, hjust = 1, size = 10)
+  }
   Background <- magick::image_read('BackgroundA.png')
   Network <- magick::image_read('NetworkA.png')
   Points <- magick::image_read('PointsA.png')
@@ -278,6 +286,10 @@ RadialSUCRA <- function(SUCRAData, ColourData, BUGSnetData, colourblind=FALSE) {
   Final <- magick::image_composite(Final,Points)
   Finalalt <- cowplot::ggdraw() +
     cowplot::draw_image(Final)
+  if (regression_text != "") {
+    Finalalt <- Finalalt + 
+      cowplot::draw_label(regression_text, x = 0.95, y = 0.05, hjust = 1, size = 10)
+  }
   
   file.remove('BackgroundO.png')
   file.remove('NetworkO.png')

--- a/R/plot.R
+++ b/R/plot.R
@@ -78,12 +78,14 @@ CreateForestPlot <- function(model, metaoutcome, bayesmin, bayesmax) {
 }
 
 # 3b Comparison of all treatment pairs
-baye_comp <- function(model, metaoutcome, outcome_measure){
-  tbl <- relative.effect.table(model$mtcResults)
-  if ((metaoutcome == "Binary") & (outcome_measure != "RD")) {
-    tbl<-exp(tbl)
-  } 
-  return(as.data.frame(round(tbl, digits=2)))
+baye_comp <- function(model, outcome_measure){
+  if (outcome_measure %in% c('OR', 'RR')) {
+    return(as.data.frame(round(exp(model$rel_eff_tbl), digits = 2)))
+  } else if (outcome_measure %in% c('RD', 'MD', 'SMD')) {
+    return(as.data.frame(round(model$rel_eff_tbl, digits = 2)))
+  } else {
+    stop("outcome_measure has to be 'OR', 'RR', 'RD', 'MD', or 'SMD'.")
+  }
 }
 
 # 3c Ranking Panel redesign by CRN

--- a/R/util.R
+++ b/R/util.R
@@ -20,7 +20,7 @@ bayesian_model <- function(sub, data, treatment_list, metaoutcome, exclusionbox,
 }
 
 # Function to create data regarding rank results - CRN
-obtain_rank_data <- function(data, metaoutcome, treatment_list, bayesmodel, rankdir, excluded = c()) {
+obtain_rank_data <- function(data, metaoutcome, treatment_list, bayesmodel, rankdir, cov_value = NA, excluded = c()) {
   newData1 <- as.data.frame(data)
   longsort2 <- dataform.df(newData1, treatment_list, metaoutcome)
   if (length(excluded > 0)) {
@@ -29,7 +29,7 @@ obtain_rank_data <- function(data, metaoutcome, treatment_list, bayesmodel, rank
   }
   # Use the self-defined function, rankdata in fn.analysis.R
   return(rankdata(NMAdata=bayesmodel$mtcResults, rankdirection=rankdir, 
-           longdata=longsort2))
+           longdata=longsort2, cov_value = cov_value))
 }
 
 #' Run the nodesplit model


### PR DESCRIPTION
Addition of the standard Bayesian tabs that contain the treatment comparisons for any pair, and the ranking panels.

Note: there is a known bug in the Radial SUCRA plot where it will sometimes not draw the network (which is the case for the test data sets). This bug has been fixed on the main app, and the fix will be included once the meta-regression feature is released in Beta.