### PR TITLE
MR47 last four baseline risk tabs

### DIFF
--- a/R/baseline_risk_analysis_panel.R
+++ b/R/baseline_risk_analysis_panel.R
@@ -28,6 +28,22 @@ baseline_risk_analysis_panel_ui <- function(id, page_numbering) {
       tabPanel(
         title = "4b-4. Ranking",
         covariate_ranking_page_ui(id = ns("baseline_risk_ranking"))
+      ),
+      tabPanel(
+        title = "4b-5. Nodesplit",
+        covariate_nodesplit_page_ui(id = ns("baseline_risk_nodesplit"), package_name = "bnma")
+      ),
+      tabPanel(
+        title = "4b-6. Result details",
+        result_details_page_ui(id = ns("baseline_risk_result_details"), item_names = c("all studies"))
+      ),
+      tabPanel(
+        title = "4b-7. Deviance report",
+        deviance_report_page_ui(id = ns("baseline_risk_deviance_report"), item_names = c("all studies"))
+      ),
+      tabPanel(
+        title = "4b-8.  Model details",
+        model_details_panel_ui(id = ns("baseline_risk_model_details"), item_names = c("regression analysis"), page_numbering)
       )
     )
   )
@@ -91,13 +107,13 @@ baseline_risk_analysis_panel_server <- function(    id,
     )
     
     # 4b-3 Treatment comparisons
-    baseline_risk_treatment_comparisons_page_server(
+    treatment_comparisons_page_baseline_risk_server(
       id = "baseline_risk_treatment_comparisons",
       model = model_reactive,
       outcome_measure = outcome_measure
     )
     
-    # 4c-4 Ranking Panel
+    # 4b-4 Ranking Panel
     covariate_ranking_page_server(
       id = "baseline_risk_ranking",
       model = model_reactive,
@@ -111,6 +127,18 @@ baseline_risk_analysis_panel_server <- function(    id,
       package = "bnma"
     )
       
+    # 4b-5 Nodesplit model
+    covariate_nodesplit_page_server(id = "baseline_risk_nodesplit")
+    
+    # 4b-6 Result details
+    result_details_page_server(id = "baseline_risk_result_details", models = c(model_reactive), package = "bnma")
+    
+    # 4b-7 Deviance report
+    deviance_report_page_server(id = "baseline_risk_deviance_report", models = c(model_reactive), package = "bnma")
+    
+    # 4c-8 Model details
+    model_details_panel_server(id = "baseline_risk_model_details", models = c(model_reactive), package = "bnma")
+    
     })
 }
 

--- a/R/bayesian/deviance/deviance_report_page.R
+++ b/R/bayesian/deviance/deviance_report_page.R
@@ -26,36 +26,47 @@ deviance_report_page_ui <- function(id, item_names) {
       "Please note: if you change the selections on the sidebar,
       you will need to re-run the primary and/or sensitivity analysis from the 'Forest Plot' page."
     ),
-    p(tags$strong("Deviance report for all studies and the sensitivity analysis")),
     
-    # This is the way to get a dynamic number of columns rendered into the row
-    do.call(
-      fluidRow,
-      lapply(
-        item_names,
-        function(name) {
-          column(
-            width = 12 / length(item_names),
-            divs["residual", name]
-          )
-        }
-      )
+    conditionalPanel(
+      condition = "output.model_type != 'consistency'",
+      ns = ns,
+      h4(tags$strong("PLEASE NOTE: the", textOutput(ns("package"), inline = TRUE), "package does not currently include unrelated-mean-effects meta-regression models, therefore the"), tags$strong(tags$em(" consistency vs UME ")), tags$strong("graph that is displayed in tab 3f is not available here."))
     ),
     
-    p(
-      "This plot represents each data points' contribution to the residual deviance for the
-      NMA with consistency (horizontal axis) and the unrelated mean effect (ume) inconsistency models
-      (vertical axis) along with the line of equality. The points on the equality line means there is no
-      improvement in model fit when using the inconsistency model, suggesting that there is no evidence of inconsistency.
-      Points above the equality line means they have a smaller residual deviance for the consistency model indicating a
-      better fit in the NMA consistency model and points below the equality line
-      means they have a better fit in the ume inconsistency model. Please note that the unrelated mean effects model
-      may not handle multi-arm trials correctly. (Further reading: Dias S, Ades AE, Welton NJ, Jansen JP, Sutton AJ. Network meta-anlaysis for
-      decision-making. Chapter 3 Model fit, model comparison and outlier detection. @2018 John Wiley & Sons Ltd.)"
+    conditionalPanel(
+      condition = "output.model_type == 'consistency'",
+      ns = ns,
+      p(tags$strong("Deviance report for all studies and the sensitivity analysis")),
+      
+      # This is the way to get a dynamic number of columns rendered into the row
+      do.call(
+        fluidRow,
+        lapply(
+          item_names,
+          function(name) {
+            column(
+              width = 12 / length(item_names),
+              divs["residual", name]
+            )
+          }
+        )
+      ),
+      
+      p(
+        "This plot represents each data points' contribution to the residual deviance for the
+        NMA with consistency (horizontal axis) and the unrelated mean effect (ume) inconsistency models
+        (vertical axis) along with the line of equality. The points on the equality line means there is no
+        improvement in model fit when using the inconsistency model, suggesting that there is no evidence of inconsistency.
+        Points above the equality line means they have a smaller residual deviance for the consistency model indicating a
+        better fit in the NMA consistency model and points below the equality line
+        means they have a better fit in the ume inconsistency model. Please note that the unrelated mean effects model
+        may not handle multi-arm trials correctly. (Further reading: Dias S, Ades AE, Welton NJ, Jansen JP, Sutton AJ. Network meta-anlaysis for
+        decision-making. Chapter 3 Model fit, model comparison and outlier detection. @2018 John Wiley & Sons Ltd.)"
+      ),
+      br(),
+      br(),
+      br()
     ),
-    br(),
-    br(),
-    br(),
     
     # This is the way to get a dynamic number of columns rendered into the row
     do.call(
@@ -127,14 +138,28 @@ deviance_report_page_ui <- function(id, item_names) {
 #' 
 #' @param id ID of the module
 #' @param models Vector of reactives containing bayesian meta-analyses.
-deviance_report_page_server <- function(id, models) {
+#' @param package "gemtc" (default) or "bnma".
+deviance_report_page_server <- function(id, models, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
+
+    output$package <- reactive(package)
+    outputOptions(x = output, name = "package", suspendWhenHidden = FALSE)
+    
+    output$model_type <- reactive(
+      if (package == "gemtc") {
+        return(models[[1]]()$mtcResults$model$type)
+      } else if (package == "bnma") {
+        return("baseline risk")
+      }
+    )
+    outputOptions(x = output, name = "model_type", suspendWhenHidden = FALSE)
+    
     # Create server for each model
     index <- 0
     sapply(
       models,
       function(mod) {
-        deviance_report_panel_server(id = as.character(index), model = mod)
+        deviance_report_panel_server(id = as.character(index), model = mod, package = package)
         # Update the index variable in the outer scope with <<-
         # This updates the variable defined above the `sapply` call instead of creating a new variable with the same name within this inner function
         index <<- index + 1
@@ -142,3 +167,4 @@ deviance_report_page_server <- function(id, models) {
     )
   })
 }
+

--- a/R/bayesian/deviance/deviance_report_panel.R
+++ b/R/bayesian/deviance/deviance_report_panel.R
@@ -29,22 +29,28 @@ deviance_report_panel_ui <- function(id, item_name) {
 #' 
 #' @param id ID of the module
 #' @param model Reactive containing bayesian meta-analysis.
-deviance_report_panel_server <- function(id, model) {
+#' @param package "gemtc" (default) or "bnma".
+deviance_report_panel_server <- function(id, model, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
 
     # Residual deviance from NMA model and UME inconsistency model
     output$dev_scat <- renderPlotly({
-      scat_plot(model())$p
+      if (package == "gemtc") {
+        return(scat_plot(model())$p)
+      } else if (package == "bnma") {
+        return(NULL)
+      }
     })
 
     # Per-arm residual deviance
     output$per_arm <- renderPlotly({
-      stemplot(model())
+      stemplot(model(), package = package)
     })
 
     # Leverage plot
     output$leverage <- renderPlotly({
-      levplot(model())
+      levplot(model(), package = package)
     })
   })
 }
+

--- a/R/bayesian/model_details_panel.R
+++ b/R/bayesian/model_details_panel.R
@@ -79,16 +79,20 @@ model_details_panel_ui <- function(id, item_names, page_numbering) {
         ),
       
         # This is the way to get a dynamic number of columns rendered into the row
-        do.call(
-          fluidRow,
-          lapply(
-            item_names,
-            function(name) {
-              column(
-                width = 12 / length(item_names),
-                divs["inconsistency", name]
-              )
-            }
+        conditionalPanel(
+          condition = "output.model_type == 'consistency'",
+          ns = ns,
+          do.call(
+            fluidRow,
+            lapply(
+              item_names,
+              function(name) {
+                column(
+                  width = 12 / length(item_names),
+                  divs["inconsistency", name]
+                )
+              }
+            )
           )
         )
       )
@@ -106,7 +110,8 @@ model_details_panel_ui <- function(id, item_names, page_numbering) {
 #' @param id ID of the module
 #' @param model Reactive containing bayesian meta-analysis for all studies
 #' @param model_sub Reactive containing meta-analysis with studies excluded
-model_details_panel_server <- function(id, models) {
+#' @param package "gemtc" (default) or "bnma".
+model_details_panel_server <- function(id, models, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
@@ -114,7 +119,11 @@ model_details_panel_server <- function(id, models) {
 
     # 3g-1 Model codes
     output$code <- renderPrint({
-      cat(main_model()$mtcResults$model$code, fill = FALSE, labels = NULL, append = FALSE)
+      if (package == "gemtc") {
+        return(cat(main_model()$mtcResults$model$code, fill = FALSE, labels = NULL, append = FALSE))
+      } else if (package == "bnma") {
+        return(cat(main_model()$network$code, fill = FALSE, labels = NULL, append = FALSE))
+      }
     })
 
     output$download_code <- downloadHandler(
@@ -123,11 +132,17 @@ model_details_panel_server <- function(id, models) {
         file.copy("./codes.txt", file)
       }
     )
-
+    
     # 3g-2 Initial values
-    output$inits <- renderPrint({
-      main_model()$mtcResults$model$inits
-    })
+    inits <- reactive(
+      if (package == "gemtc") {
+        return(main_model()$mtcResults$model$inits)
+      } else if (package == "bnma") {
+        return(main_model()$inits)
+      }
+    )
+    
+    output$inits <- renderPrint(inits())
 
     #' Create a download handler for the initial values for a given chain
     #'
@@ -135,12 +150,13 @@ model_details_panel_server <- function(id, models) {
     #' @return The created download handler
     create_chain_initial_data_download_handler <- function(index) {
       filename <- paste0("initialvalues_chain", index, ".txt")
+      
       return(
         downloadHandler(
           filename = filename,
           content = function(file) {
             lapply(
-              main_model()$mtcResults$model$inits[[index]],
+              inits(),
               write,
               file,
               append = TRUE,
@@ -158,6 +174,14 @@ model_details_panel_server <- function(id, models) {
 
     # 3g-3 Chain data.
 
+    samples <- reactive(
+      if (package == "gemtc") {
+        return(main_model()$mtcResults$samples)
+      } else if (package == "bnma") {
+        return(main_model()$samples)
+      }
+    )
+    
     #' Create a download handler for the data for a given chain
     #'
     #' @param index the Index of the chain
@@ -167,7 +191,7 @@ model_details_panel_server <- function(id, models) {
         downloadHandler(
           filename = paste0("data_for_chain_", index, ".csv"),
           content = function(file) {
-            data <- as.data.frame(main_model()$mtcResults$samples[[index]])
+            data <- as.data.frame(samples()[[index]])
             write.csv(data, file)
           }
         )
@@ -181,6 +205,17 @@ model_details_panel_server <- function(id, models) {
 
     # 3g-4 Output deviance
     
+    model_type <- reactive(
+      if (package == "gemtc") {
+        return(main_model()$mtcResults$model$type)
+      } else if (package == "bnma") {
+        return("baseline risk")
+      }
+    )
+    
+    output$model_type <- reactive(model_type())
+    outputOptions(x = output, name = "model_type", suspendWhenHidden = FALSE)
+    
     # Create server for each model
     index <- 0
     sapply(
@@ -188,18 +223,26 @@ model_details_panel_server <- function(id, models) {
       function(mod) {
         # NMA consistency model
         output[[glue::glue("dev_{index}")]] <- renderPrint({
-          mtc.deviance({mod()$mtcResults})
+          if (package == "gemtc") {
+            return(mtc.deviance({mod()$mtcResults}))
+          } else if (package == "bnma") {
+            return(mod()$deviance)
+          }
         })
         
         # UME inconsistency model
         output[[glue::glue("dev_ume_{index}")]] <- renderText({
-          printed_output <- capture.output(scat_plot(mod())$y)
-          
-          # Strip out progress bars
-          progress_bar_lines <- grep("^(\\s*\\|\\s+\\|(\\+|\\*)*?\\s*\\|\\s+[0-9]+%)+$", printed_output)
-          printed_output <- printed_output[-progress_bar_lines]
-          
-          return(paste0(printed_output, collapse = "\n"))
+          if (model_type() != "consistency") {
+            return(NULL)
+          } else {
+            printed_output <- capture.output(scat_plot(mod())$y)
+            
+            # Strip out progress bars
+            progress_bar_lines <- grep("^(\\s*\\|\\s+\\|(\\+|\\*)*?\\s*\\|\\s+[0-9]+%)+$", printed_output)
+            printed_output <- printed_output[-progress_bar_lines]
+            
+            return(paste0(printed_output, collapse = "\n"))
+          }
         })
         
         index <<- index + 1
@@ -207,3 +250,4 @@ model_details_panel_server <- function(id, models) {
     )
   })
 }
+

--- a/R/bayesian/result_details_page.R
+++ b/R/bayesian/result_details_page.R
@@ -41,7 +41,8 @@ result_details_page_ui <- function(id, item_names) {
 #' 
 #' @param id ID of the module
 #' @param models Vector of reactives containing bayesian meta-analyses.
-result_details_page_server <- function(id, models) {
+#' @param package "gemtc" (default) or "bnma".
+result_details_page_server <- function(id, models, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
     # Create server for each model
     index <- 0
@@ -50,7 +51,8 @@ result_details_page_server <- function(id, models) {
       function(mod) {
         serv <- result_details_panel_server(
           id = as.character(index),
-          model = mod
+          model = mod,
+          package = package
         )
         # Update the index variable in the outer scope with <<-
         # This updates the variable defined above the `sapply` call instead of creating a new variable with the same name within this inner function
@@ -60,3 +62,4 @@ result_details_page_server <- function(id, models) {
     )
   })
 }
+

--- a/R/bayesian/result_details_panel.R
+++ b/R/bayesian/result_details_panel.R
@@ -15,22 +15,74 @@ result_details_panel_ui <- function(id, item_name) {
 }
 
 
+
 #' Module server for the result details panel.
 #' 
 #' @param id ID of the module
 #' @param model Reactive containing bayesian meta-analysis
-result_details_panel_server <- function(id, model) {
+#' @param package "gemtc" (default) or "bnma".
+result_details_panel_server <- function(id, model, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
     
     # Results details
     output$gemtc_results <- renderPrint ({
-      model()$sumresults
+      if (package == "gemtc") {
+        return(model()$sumresults)
+      } else if (package == "bnma") {
+        return(summary(model()))
+      }
+    })
+    
+    #Need to use bnma terminology for covariate parameters below
+    cov_parameters <- reactive({
+      if (model()$network$baseline == "common"){
+        return("shared")
+      } else if (model()$network$baseline == "independent"){
+        return("unrelated")
+      } else {
+        return(model()$network$baseline)
+      }
+    })
+    
+    #The parameters to display in Gelman plots
+    parameters <- reactive({
+      if (package == "gemtc") {
+        return(model()$mtcResults$model$monitors$enabled)
+      } else if (package == "bnma") {
+        return(GetBnmaParameters(all_parameters = attr(model()$samples[[1]], "dimnames")[[2]],
+                                 effects_type = model()$network$type,
+                                 cov_parameters = cov_parameters()))
+      }
+    })
+    
+    #For baseline risk, create a Gelman plot for each parameter
+    gelman_plots <- reactive({
+      if (package == "gemtc") {
+        return(NULL)
+      } else if (package == "bnma") {
+        return(
+          lapply(parameters(),
+                 function(parameter){
+                   return(coda::gelman.plot(model()$samples[, parameter]))
+                 }
+          ))
+      }
+    })
+    
+    #The number of rows, to determine the dimensions of the grid in bnma, and the height of the plot in bnma and gemtc
+    n_rows <- reactive({
+      ceiling(length(parameters()) / 2)
     })
     
     # Gelman plots
     output$gemtc_gelman <- renderPlot ({
-      gelman.plot(model()$mtcResults)
-    })
-    
+      if (package == "gemtc") {
+        return(gelman.plot(model()$mtcResults))
+      } else if (package == "bnma") {
+        par(mfrow = c(n_rows(), 2))
+        return(BnmaGelmanPlots(gelman_plots = gelman_plots(), parameters = parameters()))
+      }
+    }, height = reactive(n_rows() * 300)
+    )
   })
 }

--- a/R/bnma_analysis.R
+++ b/R/bnma_analysis.R
@@ -179,3 +179,27 @@ BnmaSwitchRanking <- function(ranking_table){
   return(as.matrix(dplyr::select(new_table, !"new_ranks")))
 }
                             
+
+#' Get the parameters that are to be displayed in Gelman plots.
+#' 
+#' @param all_parameters Vector of monitored parameters from a bnma model.
+#' @param effects_type "fixed" or "random".
+#' @param cov_parameters "shared", "exchangeable", or "unrelated".
+#' @return Vector of treatment effect and covariate parameter names, plus random effects sd and/or exchangeable covariate sd.
+GetBnmaParameters <- function(all_parameters, effects_type, cov_parameters){
+  #Extract parameters which begin with "d[" or "b_bl[", except d[1] and b_bl[1]
+  parameters <- grep("(d|b_bl)\\[[2-9][0-9]*",
+                     all_parameters,
+                     value = TRUE)
+  if (effects_type == "random") {
+    parameters <- c(parameters, "sd")
+  } else if (effects_type != "fixed") {
+    stop("effects_type must be 'fixed' or 'random'")
+  }
+  if (cov_parameters == "exchangeable") {
+    parameters <- c(parameters, "sdB")
+  } else if (!cov_parameters %in% c("shared", "unrelated")) {
+    stop("cov_parameters must be 'shared', 'exchangeable' or 'unrelated'")
+  }
+  return(parameters)
+}

--- a/R/meta_regression/treatment_comparison_page.R
+++ b/R/meta_regression/treatment_comparison_page.R
@@ -74,7 +74,7 @@ covariate_treatment_comparisons_page_server <- function(
 #' @param id ID of the module
 #' @param model Reactive containing covariate regression meta-analysis for all studies
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD" or "OR"
-baseline_risk_treatment_comparisons_page_server <- function(
+treatment_comparisons_page_baseline_risk_server <- function(
     id,
     model,
     outcome_measure

--- a/tests/testthat/test-bnma_analysis.R
+++ b/tests/testthat/test-bnma_analysis.R
@@ -247,3 +247,31 @@ test_that("BnmaSwitchRanking() works", {
   
   expect_equal(BnmaSwitchRanking(ranking_table), expected_table)
 })
+
+
+
+test_that("GetBnmaParameters returns the correct parameters", {
+  all_parameters <- c("d[1]", "d[2]", "d[3]", "b_bl[1]", "b_bl[2]", "b_bl[3]", "sd", "sdB", "sd1", "delta[2]", "B_BL[3]")
+  expected_parameters_fixed_shared <- c("d[2]", "d[3]", "b_bl[2]", "b_bl[3]")
+  expected_parameters_random_unrelated <- c("d[2]", "d[3]", "b_bl[2]", "b_bl[3]", "sd")
+  expected_parameters_fixed_exchangeable <- c("d[2]", "d[3]", "b_bl[2]", "b_bl[3]", "sdB")
+  expected_parameters_random_exchangeable <- c("d[2]", "d[3]", "b_bl[2]", "b_bl[3]", "sd", "sdB")
+    
+  bnma_parameters_fixed_shared <- GetBnmaParameters(all_parameters = all_parameters,
+                                                    effects_type = "fixed",
+                                                    cov_parameters = "shared")
+  bnma_parameters_random_unrelated <- GetBnmaParameters(all_parameters = all_parameters,          
+                                                        effects_type = "random",
+                                                        cov_parameters = "unrelated")
+  bnma_parameters_fixed_exchangeable <- GetBnmaParameters(all_parameters = all_parameters,
+                                                          effects_type = "fixed",
+                                                          cov_parameters = "exchangeable")
+  bnma_parameters_random_exchangeable <- GetBnmaParameters(all_parameters = all_parameters,
+                                                           effects_type = "random",
+                                                           cov_parameters = "exchangeable")
+  
+  expect_equal(expected_parameters_fixed_shared, bnma_parameters_fixed_shared)
+  expect_equal(expected_parameters_random_unrelated, bnma_parameters_random_unrelated)
+  expect_equal(expected_parameters_fixed_exchangeable, bnma_parameters_fixed_exchangeable)
+  expect_equal(expected_parameters_random_exchangeable, bnma_parameters_random_exchangeable)
+})


### PR DESCRIPTION
For these four tabs I have not created new server functions, instead I have modified the old one to include {bnma}. For consistency, this could also be done for the previous tabs in a later task.

I have not added the fancy numbering system, that will be the next task, as this is already quite a lot of change.

As well as removing the UME graph for covariate regression (and baseline risk) I have removed the UME model details in tabs 4b8 and 4c8.

I could not get the Gelman plots to display in a grid using bnma::network.gelman.plot, so I have recreated them manually and used par(mfrow = c(x,y)). Related to this, there were some occasions when not all the plots were displaying in the covariate regression. So when I create the grid size in bnma, I have also applied this to the covariate regression, which means all graphs are displayed in both cases.

To help with your review I have created a separate file to test a couple of things. One is that the Gelman plots mentioned in the previous point are faithfully recreated. The other is that the deviance statitistics in tab 4b7 are assigned to the correct studies. I thought this last check was necessary because I have reused the plots that took gemtc output as input, with bnma output passed to the functions as if they had come from gemtc.
The file is on Jira.