### PR TITLE
mr-52-fix-contributions-in-contribution-matrix

### DIFF
--- a/R/contribution_matrix.R
+++ b/R/contribution_matrix.R
@@ -724,8 +724,12 @@ CreateContributionMatrix <- function(data, treatment_ids, outcome_type, outcome_
                                                treatments = treatments,
                                                outcome_type = outcome_type,
                                                outcome_measure = outcome_measure)$effect_sizes$Effect
-    #Multiply the n-th row of 'contribution' by the n-th element of 'effect_sizes'
-    contribution <- contribution * effect_sizes
+    #Create an effect size matrix in order to do the multiplication in the next step
+    effect_size_matrix <- matrix(rep(effect_sizes, each = nrow(contribution)),
+                                 nrow = nrow(contribution)
+                                 )
+    #Multiply the n-th column of 'contribution' by the n-th element of 'effect_sizes'
+    contribution <- contribution * effect_size_matrix
   } else if (weight_or_contribution != "weight") {
     stop("weight_or_contribution must be 'weight' or 'contribution'")
   }


### PR DESCRIPTION
Weinblatt1999 now has a contribution when `weight_or_contribution = "contribution"`.

If you look at the row for Strand2006 and compare `weight_or_contribution = "contribution"` to `weight_or_contribution = "weight"` you see that this study now has zeros when `weight_or_contribution = "contribution"`. In this case it is correct, because both arms have the same outcome (R = 5, N = 40), so the treatment effect is zero and the arms cancel each other out.