### PR TITLE
Mr 61 baseline risk confidence regions

### DIFF
--- a/R/bnma_analysis.R
+++ b/R/bnma_analysis.R
@@ -138,7 +138,7 @@ BaselineRiskRegression <- function(br_data, treatment_ids, outcome_type, ref,  e
 #'  covariate_min = Vector of minimum covariate values directly contributing to the regression.
 #'  covariate_max = Vector of maximum covariate values directly contributing to the regression.
 BaselineRiskModelOutput <- function(data, treatment_ids, model, outcome_measure) {
-  
+
   treatments <- model$network$Treat.order
   reference <- unname(treatments[1])
   comparator_names <- unname(treatments[-1])
@@ -267,6 +267,90 @@ GetReferenceOutcome <- function(data, treatment_ids, outcome_type, observed, mod
 
 
 
+#' Calculate the confidence regions within direct evidence for the baseline risk model.
+#'
+#' @param model_output Return from `BaselineRiskModelOutput()`.
+#'
+#' @return list of confidence region objects and confidence interval objects.
+#' Regions cover treatments with a non-zero covariate range of direct contributions,
+#' intervals cover treatments with a single covariate value from direct contributions.
+#' Any treatment with no direct contributions will not be present in either list.
+#' Each is a list of data frames for each treatment name. Each data frame contains 3 columns:
+#' - cov_value: The covariate value at which the confidence region is calculated.
+#' - lower: the 2.5% quantile.
+#' - upper: the 97.5% quantile.
+#' Each data frame in "regions" contains 11 rows creating a 10-polygon region.
+#' Each data frame in "intervals" contains a single row at the covariate value of that single contribution.
+CalculateConfidenceRegionsBnma <- function(model_output) {
+  
+  mtc_results <- model_output$mtcResults
+  treatments <- mtc_results$network$Treat.order
+  
+  confidence_regions <- list()
+  confidence_intervals <- list()
+  
+  for (treatment_name in model_output$comparator_names) {
+    parameter_name <- glue::glue("d[", which(treatment_name == unname(treatments)), "]")
+    cov_min <- model_output$covariate_min[treatment_name]
+    cov_max <- model_output$covariate_max[treatment_name]
+    
+    if (is.na(cov_min)) {
+      confidence_intervals[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+      confidence_regions[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+    } else if (cov_min == cov_max) {
+      interval <- .FindConfidenceIntervalBnma(mtc_results, cov_min, parameter_name)
+      df <- data.frame(cov_value = cov_min, lower = interval["2.5%"], upper = interval["97.5%"])
+      
+      # Strip out the row names
+      rownames(df) <- NULL
+      
+      # Add to regions list
+      confidence_intervals[[treatment_name]] <- df
+      confidence_regions[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+    } else {
+      df <- data.frame()
+      for (cov_value in seq(from = cov_min, to = cov_max, length.out = 11)) {
+        interval <- .FindConfidenceIntervalBnma(mtc_results, cov_value, parameter_name)
+        df <- rbind(
+          df,
+          data.frame(cov_value = cov_value, lower = interval["2.5%"], upper = interval["97.5%"])
+        )
+      }
+      
+      # Strip out the row names
+      rownames(df) <- NULL
+      
+      # Add to regions list
+      confidence_regions[[treatment_name]] <- df
+      confidence_intervals[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+    }
+  }
+  
+  return(
+    list(
+      regions = confidence_regions,
+      intervals = confidence_intervals
+    )
+  )
+}
+
+
+
+#' Find the confidence interval at a given covariate value.
+#'
+#' @param mtc_results Meta-analysis object from which to find confidence interval.
+#' @param reference_name Name of reference treatment.
+#' @param cov_value Covariate value at which to find the confidence interval.
+#' @param parameter_name Name of the parameter for which to get the confidence interval.
+#'
+#' @return Named vector of "2.5%" and "97.5" quantiles.
+.FindConfidenceIntervalBnma <- function(mtc_results, cov_value, parameter_name) {
+  rel_eff <- BnmaRelativeEffects(model = mtc_results, covariate_value = cov_value)
+  return(rel_eff[parameter_name, c("2.5%", "97.5%")])
+}
+
+
+
 #' Creates a DIC table in gemtc format from a bnma model
 #'
 #' @param br_model Output from bnma::network.run(), typically created from BaselineRiskRegression().
@@ -355,4 +439,40 @@ GetBnmaParameters <- function(all_parameters, effects_type, cov_parameters) {
     stop("cov_parameters must be 'shared', 'exchangeable' or 'unrelated'")
   }
   return(parameters)
+}
+
+
+
+
+#' An equivalent to {gemtc}'s relative.effect() function, for baseline risk in {bnma}.
+#' 
+#' @param model bnma model object created by BaselineRiskRegression().
+#' @param covariate_value The covariate value at which to calculate relative effects.
+#' @return Matrix with the median and 95% credible interval relative effect
+#'  - columns: '50%', '2.5%' and '97.5%'
+#'  - rows: one row per non-reference treatment, named by the corresponding treatment parameter (e.g. the first one is d[2]).
+BnmaRelativeEffects <- function(model, covariate_value) {
+  
+  # browser()
+  
+  model_summary <- summary(model)
+  parameters <- rownames(model_summary$summary.samples$quantiles)
+  #Extract parameters that begin with "d[", except d[1]
+  treatment_parameters <- grep("d\\[([0-9][0-9]+|[2-9])\\]",
+                               parameters,
+                               value = TRUE)
+  #Extract parameters that begin with "b_bl[", except b_bl[1]
+  covariate_parameters <- grep("b_bl\\[([0-9][0-9]+|[2-9])\\]",
+                               parameters,
+                               value = TRUE)
+  centred_covariate_value <- covariate_value - model$network$mx_bl
+  
+  samples <- list()
+  #The number of chains is always left at the default 3
+  for (chain in 1:3) {
+    samples[[chain]] <- model$samples[[chain]][, treatment_parameters] + centred_covariate_value * model$samples[[chain]][, covariate_parameters]
+  }
+  
+  relative_effects <- MCMCvis::MCMCsummary(samples)
+  return(as.matrix(relative_effects[, c("50%", "2.5%", "97.5%")]))
 }


### PR DESCRIPTION
`CalculateConfidenceRegionsBnma()` and `.FindConfidenceIntervalBnma()` both work, (as does `BnmaRelativeEffects()`, though that is not for review in this task, it's in mr-60). If I remove all the `ExtendedTask` code then it all works.

I have tried to modify the `ExtendedTask$new` code to call `CalculateConfidenceRegions()` or `CalculateConfidenceRegionsBnma()` depending on the value of `package`, to no avail. I have commited three attempts which are commented out. I have also tried adding `package` as another parameter to the function within `ExtendedTask$new` but that didn't work either. I'm stuck now and would appreciate some help!