### PR TITLE
Hot fix for regression graph

### DIFF
--- a/R/meta_regression/composite_regression_plot.R
+++ b/R/meta_regression/composite_regression_plot.R
@@ -1,6 +1,6 @@
 
 # Zero-width space before "Other" to pin it to the first item in the list
-regression_ghost_name = "\u200BOther"
+regression_ghost_name = "\"Other\""
 
 #' Create a composite meta-regression plot which comprises plots showing direct and indirect evidence.
 #'


### PR DESCRIPTION
Changed hidden character to quoted text for simplicity. The data had to be sorted alphabetically due to a limitation in {ggplot2}. This might be fixable in a better way, but that will take significant investigation. The committed change is a quick-fix for the issue at hand.