### PR TITLE
Mi 68 regression plot binary covariate bug

### DIFF
--- a/R/home_page.R
+++ b/R/home_page.R
@@ -47,7 +47,7 @@ home_page_ui <- function(id) {
             tags$li(
               "Meta-regression has been added. One covariate is allowed, which can be a new continuous or binary variable,
               or baseline risk. Two new graphs are available for meta-regression. The first displays the covariate values grouped by
-              treatment and study. The second plots the covariate against relative treatment effects, with confidence regions and
+              treatment and study. The second plots the covariate against relative treatment effects, with credible regions and
               study-level contributions."
             )
           )

--- a/R/meta_regression/composite_regression_plot.R
+++ b/R/meta_regression/composite_regression_plot.R
@@ -10,14 +10,14 @@ regression_ghost_name = "\"Other\""
 #' @param comparators Vector of names of comparison treatments to plot in colour.
 #' @param contribution_matrix Contributions from function `CalculateContributions()`.
 #' @param contribution_type Type of contribution, used to calculate sizes for the study contribution circles.
-#' @param confidence_regions List of confidence region data frames from function `CalculateConfidenceRegions()`.
+#' @param credible_regions List of credible region data frames from function `CalculateCredibleRegions()`.
 #' @param include_covariate TRUE if the value of the covariate is to be plotted as a vertical line. Defaults to FALSE.
 #' @param include_ghosts TRUE if all other comparator studies should be plotted in grey in the background of the plot. Defaults to FALSE.
 #' @param include_extrapolation TRUE if regression lines should be extrapolated beyond the range of the given data. These will appear as dashed lines.
 #' Defaults to FALSE.
-#' @param include_confidence TRUE if the confidence regions should be plotted for the specified comparators. These will be partially transparent regions.
+#' @param include_credible TRUE if the credible regions should be plotted for the specified comparators. These will be partially transparent regions.
 #' Defaults to FALSE.
-#' @param confidence_opacity The opacity of the confidence regions. Can be any value between 0 and 1, inclusive. Defaults to 0.2.
+#' @param credible_opacity The opacity of the credible regions. Can be any value between 0 and 1, inclusive. Defaults to 0.2.
 #' @param include_contributions TRUE if the contributions should be plotted as a circle for each study. Defaults to TRUE.
 #' @param contribution_multiplier Factor by which to scale the sizes of the study contribution circles. Defaults to 1.0.
 #' @param legend_position String informing the position of the legend. Acceptable values are:
@@ -34,12 +34,12 @@ CreateCompositeMetaRegressionPlot <- function(
     comparators,
     contribution_matrix,
     contribution_type,
-    confidence_regions,
+    credible_regions,
     include_covariate = FALSE,
     include_ghosts = FALSE,
     include_extrapolation = FALSE,
-    include_confidence = FALSE,
-    confidence_opacity = 0.2,
+    include_credible = FALSE,
+    credible_opacity = 0.2,
     include_contributions = TRUE,
     contribution_multiplier = 1.0,
     legend_position = "BR") {
@@ -51,12 +51,12 @@ CreateCompositeMetaRegressionPlot <- function(
     comparators = comparators,
     contribution_matrix = contribution_matrix,
     contribution_type = contribution_type,
-    confidence_regions = confidence_regions,
+    credible_regions = credible_regions,
     include_covariate = include_covariate,
     include_ghosts = include_ghosts,
     include_extrapolation = include_extrapolation,
-    include_confidence = include_confidence,
-    confidence_opacity = confidence_opacity,
+    include_credible = include_credible,
+    credible_opacity = credible_opacity,
     include_contributions = include_contributions,
     contribution_multiplier = contribution_multiplier,
     legend_position = legend_position

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -207,7 +207,8 @@ covariate_analysis_panel_server <- function(
         model = model_reactive(),
         covariate_title = covariate_title(),
         cov_value = covariate_value(),
-        outcome_measure = outcome_measure()
+        outcome_measure = outcome_measure(),
+        covariate_type = covariate_type()
       )
     })
     

--- a/R/meta_regression/gemtc_analysis.R
+++ b/R/meta_regression/gemtc_analysis.R
@@ -250,26 +250,26 @@ FindCovariateDefault <- function(model) {
   return(cov_value)
 }
 
-#' Calculate the confidence regions within direct evidence for the regression model.
+#' Calculate the credible regions within direct evidence for the regression model.
 #'
 #' @param model_output Return from `CovariateModelOutput()`.
 #'
-#' @return list of confidence region objects and confidence interval objects.
+#' @return list of credible region objects and credible interval objects.
 #' Regions cover treatments with a non-zero covariate range of direct contributions,
 #' intervals cover treatments with a single covariate value from direct contributions.
 #' Any treatment with no direct contributions will not be present in either list.
 #' Each is a list of data frames for each treatment name. Each data frame contains 3 columns:
-#' - cov_value: The covariate value at which the confidence region is calculated.
+#' - cov_value: The covariate value at which the credible region is calculated.
 #' - lower: the 2.5% quantile.
 #' - upper: the 97.5% quantile.
 #' Each data frame in "regions" contains 11 rows creating a 10-polygon region.
 #' Each data frame in "intervals" contains a single row at the covariate value of that single contribution.
-CalculateConfidenceRegions <- function(model_output) {
+CalculateCredibleRegions <- function(model_output) {
   mtc_results <- model_output$mtcResults
   reference_name <- model_output$reference_name
   
-  confidence_regions <- list()
-  confidence_intervals <- list()
+  credible_regions <- list()
+  credible_intervals <- list()
   
   for (treatment_name in model_output$comparator_names) {
     parameter_name <- glue::glue("d.{reference_name}.{treatment_name}")
@@ -278,20 +278,20 @@ CalculateConfidenceRegions <- function(model_output) {
     
     if (is.na(cov_min)) {
       
-      confidence_intervals[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
-      confidence_regions[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+      credible_intervals[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+      credible_regions[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
       
     } else if (cov_min == cov_max) {
       
-      interval <- .FindConfidenceInterval(mtc_results, reference_name, cov_min, parameter_name)
+      interval <- .FindCredibleInterval(mtc_results, reference_name, cov_min, parameter_name)
       df <- data.frame(cov_value = cov_min, lower = interval["2.5%"], upper = interval["97.5%"])
       
       # Strip out the row names
       rownames(df) <- NULL
       
       # Add to regions list
-      confidence_intervals[[treatment_name]] <- df
-      confidence_regions[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+      credible_intervals[[treatment_name]] <- df
+      credible_regions[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
       
     } else {
       
@@ -305,7 +305,7 @@ CalculateConfidenceRegions <- function(model_output) {
       }
       
       for (cov_value in cov_value_sequence) {
-        interval <- .FindConfidenceInterval(mtc_results, reference_name, cov_value, parameter_name)
+        interval <- .FindCredibleInterval(mtc_results, reference_name, cov_value, parameter_name)
         df <- rbind(
           df,
           data.frame(cov_value = cov_value, lower = interval["2.5%"], upper = interval["97.5%"])
@@ -317,11 +317,11 @@ CalculateConfidenceRegions <- function(model_output) {
       
       # Add to regions list
       if (model_output$mtcResults$model$regressor$type == "continuous") {
-        confidence_regions[[treatment_name]] <- df
-        confidence_intervals[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+        credible_regions[[treatment_name]] <- df
+        credible_intervals[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
       } else if (model_output$mtcResults$model$regressor$type == "binary") {
-        confidence_regions[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
-        confidence_intervals[[treatment_name]] <- df
+        credible_regions[[treatment_name]] <- data.frame(cov_value = NA, lower = NA, upper = NA)
+        credible_intervals[[treatment_name]] <- df
       }
     }
   }
@@ -330,21 +330,21 @@ CalculateConfidenceRegions <- function(model_output) {
 
   return(
     list(
-      regions = confidence_regions,
-      intervals = confidence_intervals
+      regions = credible_regions,
+      intervals = credible_intervals
     )
   )
 }
 
-#' Find the confidence interval at a given covariate value.
+#' Find the credible interval at a given covariate value.
 #'
-#' @param mtc_results Meta-analysis object from which to find confidence interval.
+#' @param mtc_results Meta-analysis object from which to find credible interval.
 #' @param reference_name Name of reference treatment.
-#' @param cov_value Covariate value at which to find the confidence interval.
-#' @param parameter_name Name of the parameter for which to get the confidence interval.
+#' @param cov_value Covariate value at which to find the credible interval.
+#' @param parameter_name Name of the parameter for which to get the credible interval.
 #'
 #' @return Named vector of "2.5%" and "97.5" quantiles.
-.FindConfidenceInterval <- function(mtc_results, reference_name, cov_value, parameter_name) {
+.FindCredibleInterval <- function(mtc_results, reference_name, cov_value, parameter_name) {
   rel_eff <- gemtc::relative.effect(mtc_results, reference_name, covariate = cov_value)
   rel_eff_summary <- summary(rel_eff)
   return(rel_eff_summary$summaries$quantiles[parameter_name, c("2.5%", "97.5%")])

--- a/R/meta_regression/indirect_contribution_plot.R
+++ b/R/meta_regression/indirect_contribution_plot.R
@@ -79,7 +79,7 @@ CreateIndirectContributionPlot <- function(
     plot = plot,
     comparators = comparators,
     include_ghosts = include_ghosts,
-    include_confidence = FALSE
+    include_credible = FALSE
   )
   
   return(plot)

--- a/R/meta_regression/main_regression_plot.R
+++ b/R/meta_regression/main_regression_plot.R
@@ -7,14 +7,14 @@
 #' @param comparators Vector of names of comparison treatments to plot in colour.
 #' @param contribution_matrix Contributions from function `CalculateContributions()`.
 #' @param contribution_type Name of the type of contribution, used to calculate sizes for the study contribution circles.
-#' @param confidence_regions List of confidence region data frames from function `CalculateConfidenceRegions()`.
+#' @param credible_regions List of credible region data frames from function `CalculateCredibleRegions()`.
 #' @param include_covariate TRUE if the value of the covariate is to be plotted as a vertical line. Defaults to FALSE.
 #' @param include_ghosts TRUE if all other comparator studies should be plotted in grey in the background of the plot. Defaults to FALSE.
 #' @param include_extrapolation TRUE if regression lines should be extrapolated beyond the range of the given data. These will appear as dashed lines.
 #' Defaults to FALSE.
-#' @param include_confidence TRUE if the confidence regions should be plotted for the specified comparators. These will be partially transparent regions.
+#' @param include_credible TRUE if the credible regions should be plotted for the specified comparators. These will be partially transparent regions.
 #' Defaults to FALSE.
-#' @param confidence_opacity The opacity of the confidence regions. Can be any value between 0 and 1, inclusive. Defaults to 0.2.
+#' @param credible_opacity The opacity of the credible regions. Can be any value between 0 and 1, inclusive. Defaults to 0.2.
 #' @param include_contributions TRUE if the contributions should be plotted as a circle for each study. Defaults to TRUE.
 #' @param contribution_multiplier Multiplication factor by which to scale the sizes of the study contribution circles. Defaults to 1.0.
 #' @param legend_position String informing the position of the legend. Acceptable values are:
@@ -32,12 +32,12 @@ CreateMainRegressionPlot <- function(
     comparators,
     contribution_matrix,
     contribution_type,
-    confidence_regions,
+    credible_regions,
     include_covariate = FALSE,
     include_ghosts = FALSE,
     include_extrapolation = FALSE,
-    include_confidence = FALSE,
-    confidence_opacity = 0.2,
+    include_credible = FALSE,
+    credible_opacity = 0.2,
     include_contributions = TRUE,
     contribution_multiplier = 1.0,
     legend_position = "BR") {
@@ -52,7 +52,7 @@ CreateMainRegressionPlot <- function(
     comparators = comparators,
     outcome_measure = outcome_measure,
     include_ghosts = include_ghosts && length(comparators) < length(all_comparators),
-    confidence_opacity = confidence_opacity,
+    credible_opacity = credible_opacity,
     legend_position = legend_position
   )
   
@@ -67,8 +67,8 @@ CreateMainRegressionPlot <- function(
   }
   
   if (length(comparators) > 0) {
-    if (include_confidence) {
-      plot <- .PlotConfidenceRegions(plot, confidence_regions, comparators, confidence_opacity)
+    if (include_credible) {
+      plot <- .PlotCredibleRegions(plot, credible_regions, comparators, credible_opacity)
     }
     if (include_contributions) {
       plot <- .PlotDirectContributionCircles(plot, model_output, treatment_df, reference, comparators, contribution_matrix, contribution_type, contribution_multiplier)
@@ -94,7 +94,7 @@ CreateMainRegressionPlot <- function(
 #' @param comparators Vector of names of comparison treatments to plot.
 #' @param outcome_measure Outcome measure of analysis (OR, RR, RD, MD)
 #' @param include_ghosts TRUE if all other comparator studies should be plotted in grey in the background of the plot. Defaults to FALSE.
-#' @param confidence_opacity The opacity of the confidence regions. Can be any value between 0 and 1, inclusive. Defaults to 0.2.
+#' @param credible_opacity The opacity of the credible regions. Can be any value between 0 and 1, inclusive. Defaults to 0.2.
 #' @param legend_position String informing the position of the legend. Acceptable values are:
 #' - "BR" - Bottom-right of the plot area
 #' - "BL" - Bottom-left of the plot area
@@ -102,7 +102,7 @@ CreateMainRegressionPlot <- function(
 #' - "TL" - Top-left of the plot area
 #'
 #' @return Created ggplot2 object.
-.SetupMainRegressionPlot <- function(reference, comparators, outcome_measure, include_ghosts, confidence_opacity, legend_position) {
+.SetupMainRegressionPlot <- function(reference, comparators, outcome_measure, include_ghosts, credible_opacity, legend_position) {
   # Set up basic plot
   plot <- ggplot() +
     theme_minimal() +
@@ -141,23 +141,23 @@ CreateMainRegressionPlot <- function(
     plot = plot,
     comparators = comparators,
     include_ghosts = include_ghosts,
-    include_confidence = TRUE,
-    confidence_opacity = confidence_opacity
+    include_credible = TRUE,
+    credible_opacity = credible_opacity
   )
   
   return(plot)
 }
 
-#' Plot the confidence regions and intervals on the plot.
+#' Plot the credible regions and intervals on the plot.
 #'
 #' @param plot object to which to add elements.
-#' @param confidence_regions List of confidence region data frames from function `CalculateConfidenceRegions()`.
+#' @param credible_regions List of credible region data frames from function `CalculateCredibleRegions()`.
 #' @param comparators Vector of names of comparison treatments to plot.
 #'
 #' @return The modified ggplot2 object.
-.PlotConfidenceRegions <- function(plot, confidence_regions, comparators, confidence_opacity) {
-  regions <- .FormatRegressionConfidenceRegion(confidence_regions$regions, comparators)
-  intervals <- .FormatRegressionConfidenceRegion(confidence_regions$intervals, comparators)
+.PlotCredibleRegions <- function(plot, credible_regions, comparators, credible_opacity) {
+  regions <- .FormatRegressionCredibleRegion(credible_regions$regions, comparators)
+  intervals <- .FormatRegressionCredibleRegion(credible_regions$intervals, comparators)
   
   plot <- plot +
     geom_ribbon(
@@ -179,7 +179,7 @@ CreateMainRegressionPlot <- function(
         color = Treatment
       ),
       linewidth = 2,
-      alpha = confidence_opacity,
+      alpha = credible_opacity,
       show.legend = FALSE
     )
   
@@ -334,17 +334,17 @@ CreateMainRegressionPlot <- function(
   )
 }
 
-#' Format the confidence regions for the regression analysis into a plottable data frame.
+#' Format the credible regions for the regression analysis into a plottable data frame.
 #'
-#' @param confidence_regions List of confidence region data frames from function `CalculateConfidenceRegions()`.
+#' @param credible_regions List of credible region data frames from function `CalculateCredibleRegions()`.
 #' @param comparator Name of comparison treatment for which to find the contributions.
 #'
-#' @return Data frame containing contribution details. Each row represents a confidence interval at a specific covariate value, for a given treatment. Columns are:
-#' - Treatment: The treatment for which this confidence interval relates.
+#' @return Data frame containing contribution details. Each row represents a credible interval at a specific covariate value, for a given treatment. Columns are:
+#' - Treatment: The treatment for which this credible interval relates.
 #' - covariate_value: Value of the covariate for this interval
 #' - y_min Relative effect of the lower end of this interval
 #' - y_max: Relative effect of the upper end of this interval
-.FormatRegressionConfidenceRegion <- function(confidence_regions, comparator) {
+.FormatRegressionCredibleRegion <- function(credible_regions, comparator) {
   
   treatments <- c()
   covariate_values <- c()
@@ -352,9 +352,9 @@ CreateMainRegressionPlot <- function(
   y_maxs <- c()
   
   for (treatment_name in comparator) {
-    treatment_covariate_values <- confidence_regions[[treatment_name]]$cov_value
-    treatment_y_mins <- confidence_regions[[treatment_name]]$lower
-    treatment_y_maxs <- confidence_regions[[treatment_name]]$upper
+    treatment_covariate_values <- credible_regions[[treatment_name]]$cov_value
+    treatment_y_mins <- credible_regions[[treatment_name]]$lower
+    treatment_y_maxs <- credible_regions[[treatment_name]]$upper
     
     treatments <- c(treatments, rep(treatment_name, length(treatment_covariate_values)))
     covariate_values <- c(covariate_values, treatment_covariate_values)
@@ -362,7 +362,7 @@ CreateMainRegressionPlot <- function(
     y_maxs <- c(y_maxs, treatment_y_maxs)
   }
   
-  confidence_df <- data.frame(
+  credible_df <- data.frame(
     Treatment = treatments,
     covariate_value = covariate_values,
     y_min = y_mins,
@@ -370,9 +370,9 @@ CreateMainRegressionPlot <- function(
   )
   
   # Return an empty data frame with correct column names if all of the rows are NA
-  if (all(is.na(confidence_df$covariate_value))) {
+  if (all(is.na(credible_df$covariate_value))) {
     return(data.frame(matrix(nrow = 0, ncol = 4, dimnames = list(NULL, c("Treatment", "covariate_value", "y_min", "y_max")))))
   }
   
-  return(confidence_df)
+  return(credible_df)
 }

--- a/R/meta_regression/plot_colours.R
+++ b/R/meta_regression/plot_colours.R
@@ -4,11 +4,11 @@
 #' @param reference Name of the reference treatment.
 #' @param comparators Vector of names of comparison treatments to plot.
 #' @param include_ghosts TRUE if all other comparator studies should be plotted in grey in the background of the plot.
-#' @param include_confidence TRUE if all other comparator studies should be plotted in grey in the background of the plot.
-#' @param confidence_opacity The opacity of the confidence regions. Can be any value between 0 and 1, inclusive. Defaults to 1.
+#' @param include_credible TRUE if all other comparator studies should be plotted in grey in the background of the plot.
+#' @param credible_opacity The opacity of the credible regions. Can be any value between 0 and 1, inclusive. Defaults to 1.
 #'
 #' @return Created ggplot2 object.
-SetupRegressionPlotColours <- function(plot, comparators, include_ghosts, include_confidence, confidence_opacity = 1) {
+SetupRegressionPlotColours <- function(plot, comparators, include_ghosts, include_credible, credible_opacity = 1) {
   # Ensure that enough colours are always provided, by cycling the given colours
   base_colours <- c("#bb0000", "#bba000", "#00bb00", "#00bbbb", "#0000bb", "#bb00bb",
                     "#ff5555", "#ffa000", "#44ff44", "#55ffff", "#7744ff", "#ff00ff")
@@ -22,10 +22,10 @@ SetupRegressionPlotColours <- function(plot, comparators, include_ghosts, includ
   plot <- plot +
     scale_colour_manual(values = colours)
   
-  # Only include fills if confidence regions included
-  if (include_confidence) {
+  # Only include fills if credible regions included
+  if (include_credible) {
     opacity_hex = format(
-      as.hexmode(as.integer(confidence_opacity * 255)),
+      as.hexmode(as.integer(credible_opacity * 255)),
       width = 2
     )
     fills <- paste0(base_colours, opacity_hex)

--- a/R/meta_regression/regression_plot_panel.R
+++ b/R/meta_regression/regression_plot_panel.R
@@ -77,24 +77,24 @@ regression_plot_panel_ui <- function(id) {
             ),
           tooltip = "Show the covariate value as a vertical line at the current value"
         ),
-        # Confidence regions
+        # Credible regions
         div(
-          id = ns("confidence_options"),
+          id = ns("credible_options"),
             checkboxInput(
-            inputId = ns("confidence"),
+            inputId = ns("credible"),
             label = div(
               .AddRegressionOptionTooltip(
-                "Show confidence regions",
+                "Show credible regions",
                 tags$i(class="fa-regular fa-circle-question"),
-                tooltip = "Show confidence regions for the added comparisons. This will not show if there is one or zero direct contributions"
+                tooltip = "Show credible regions for the added comparisons. This will not show if there is one or zero direct contributions"
               ),
-              uiOutput(outputId = ns("confidence_info")),
+              uiOutput(outputId = ns("credible_info")),
               style = "display: -webkit-inline-box;"
             )
           ),
           sliderInput(
-            inputId = ns("confidence_opacity"),
-            label = "Confidence Region Opacity",
+            inputId = ns("credible_opacity"),
+            label = "Credible Region Opacity",
             min = 0,
             max = 0.5,
             step = 0.01,
@@ -216,9 +216,9 @@ regression_plot_panel_server <- function(id, data, covariate_title, covariate_na
     
     added_comparators <- add_remove_panel_server(id = "added_comparators", reactive({ treatment_df()$RawLabel }), reference)
     
-    # Disable opacity when confidence regions not shown
+    # Disable opacity when credible regions not shown
     observe({
-      shinyjs::toggleState(id = "confidence_opacity", condition = input$confidence)
+      shinyjs::toggleState(id = "credible_opacity", condition = input$credible)
     })
     
     # Disable contribution options when contributions not shown
@@ -234,52 +234,52 @@ regression_plot_panel_server <- function(id, data, covariate_title, covariate_na
       stop("'package' must be 'gemtc' or 'bnma'")
     }
     
-    # Background process to calculate confidence regions
-    confidence_regions <- shiny::ExtendedTask$new(function(model_output) {
+    # Background process to calculate credible regions
+    credible_regions <- shiny::ExtendedTask$new(function(model_output) {
       promises::future_promise({
         if (package == "gemtc") {
-          return(CalculateConfidenceRegions(model_output))
+          return(CalculateCredibleRegions(model_output))
         } else if (package == "bnma") {
-          return(CalculateConfidenceRegionsBnma(model_output))
+          return(CalculateCredibleRegionsBnma(model_output))
         }
       })
     })
     
-    # Start calculation of confidence regions when the model output changes
+    # Start calculation of credible regions when the model output changes
     observe({
-      confidence_regions$invoke(model_output())
+      credible_regions$invoke(model_output())
     }) |>
       bindEvent(model_output())
 
-    calculating_confidence_regions <- reactiveVal(FALSE)
-    previous_confidence_regions_shown <- reactiveVal(FALSE)
+    calculating_credible_regions <- reactiveVal(FALSE)
+    previous_credible_regions_shown <- reactiveVal(FALSE)
 
-    # When model output changes, save the current state of the confidence region checkbox, then deselect and disable it
+    # When model output changes, save the current state of the credible region checkbox, then deselect and disable it
     observe({
-      calculating_confidence_regions(TRUE)
-      previous_confidence_regions_shown(input$confidence)
-      updateCheckboxInput(inputId = "confidence", value = FALSE)
-      shinyjs::disable(id = "confidence_options")
+      calculating_credible_regions(TRUE)
+      previous_credible_regions_shown(input$credible)
+      updateCheckboxInput(inputId = "credible", value = FALSE)
+      shinyjs::disable(id = "credible_options")
     }) |>
       bindEvent(model_output())
 
-    # When the confidence regions have been calculated, reenable the checkbox, and reset its value
+    # When the credible regions have been calculated, reenable the checkbox, and reset its value
     observe({
-      shinyjs::enable(id = "confidence_options")
-      updateCheckboxInput(inputId = "confidence", value = previous_confidence_regions_shown())
-      calculating_confidence_regions(FALSE)
+      shinyjs::enable(id = "credible_options")
+      updateCheckboxInput(inputId = "credible", value = previous_credible_regions_shown())
+      calculating_credible_regions(FALSE)
     }) |>
-      bindEvent(confidence_regions$result())
+      bindEvent(credible_regions$result())
 
-    # Show a spinner when the confidence regions are being calculated
-    output$confidence_info <- renderUI({
-      if (!calculating_confidence_regions()) {
+    # Show a spinner when the credible regions are being calculated
+    output$credible_info <- renderUI({
+      if (!calculating_credible_regions()) {
         return(NULL)
       }
 
       .AddRegressionOptionTooltip(
         tags$i(class = "fa-solid fa-circle-notch fa-spin"),
-        tooltip = "Calculating confidence regions",
+        tooltip = "Calculating credible regions",
         style = "color: blue;"
       )
     })
@@ -398,12 +398,12 @@ regression_plot_panel_server <- function(id, data, covariate_title, covariate_na
             comparators = comparator_titles(),
             contribution_matrix = contribution_matrix(),
             contribution_type = input$absolute_relative_toggle,
-            confidence_regions = confidence_regions$result(),
+            credible_regions = credible_regions$result(),
             include_covariate = input$covariate,
             include_ghosts = input$ghosts,
             include_extrapolation = input$extrapolate,
-            include_confidence = input$confidence,
-            confidence_opacity = input$confidence_opacity,
+            include_credible = input$credible,
+            credible_opacity = input$credible_opacity,
             include_contributions = input$contributions != "None",
             contribution_multiplier = input$circle_multipler,
             legend_position = input$legend_position_dropdown
@@ -437,12 +437,12 @@ regression_plot_panel_server <- function(id, data, covariate_title, covariate_na
             comparators = comparator_titles(),
             contribution_matrix = contribution_matrix(),
             contribution_type = input$absolute_relative_toggle,
-            confidence_regions = confidence_regions$result(),
+            credible_regions = credible_regions$result(),
             include_covariate = input$covariate,
             include_ghosts = input$ghosts,
             include_extrapolation = input$extrapolate,
-            include_confidence = input$confidence,
-            confidence_opacity = input$confidence_opacity,
+            include_credible = input$credible,
+            credible_opacity = input$credible_opacity,
             include_contributions = input$contributions != "None",
             contribution_multiplier = input$circle_multipler,
             legend_position = input$legend_position_dropdown

--- a/tests/testthat/test-gemtc_analysis.R
+++ b/tests/testthat/test-gemtc_analysis.R
@@ -210,7 +210,7 @@ test_that("RunCovariateModel() gives reproducible output. Follow on: FindCovaria
   expect_equal(output_1$comparator_names, c("the_Butcher", "the_Dung_named", "the_Great", "the_Slit_nosed", "the_Younger"))
 })
 
-test_that("CalculateConfidenceRegions() gives nothing for NA evidence range", {
+test_that("CalculateCredibleRegions() gives nothing for NA evidence range", {
   mtc_results <- list()
   
   model_output <- list(
@@ -221,7 +221,7 @@ test_that("CalculateConfidenceRegions() gives nothing for NA evidence range", {
     covariate_max = c(Ibuprofen = NA)
   )
   
-  result <- CalculateConfidenceRegions(model_output)
+  result <- CalculateCredibleRegions(model_output)
   
   expect_equal(names(result$intervals), c("Ibuprofen"))
   expect_equal(names(result$regions), c("Ibuprofen"))
@@ -240,7 +240,7 @@ test_that("CalculateConfidenceRegions() gives nothing for NA evidence range", {
   )
 })
 
-test_that("CalculateConfidenceRegions() gives interval for zero-width evidence range", {
+test_that("CalculateCredibleRegions() gives interval for zero-width evidence range", {
   mtc_results <- list()
   
   model_output <- list(
@@ -259,9 +259,9 @@ test_that("CalculateConfidenceRegions() gives interval for zero-width evidence r
     )
   )
   
-  mockery::stub(CalculateConfidenceRegions, ".FindConfidenceInterval", interval)
+  mockery::stub(CalculateCredibleRegions, ".FindCredibleInterval", interval)
   
-  result <- CalculateConfidenceRegions(model_output)
+  result <- CalculateCredibleRegions(model_output)
   
   expect_equal(names(result$regions), c("Ibuprofen"))
   expect_equal(names(result$intervals), c("Ibuprofen"))
@@ -280,7 +280,7 @@ test_that("CalculateConfidenceRegions() gives interval for zero-width evidence r
   )
 })
 
-test_that("CalculateConfidenceRegions() gives region for non-zero-width evidence range", {
+test_that("CalculateCredibleRegions() gives region for non-zero-width evidence range", {
   mtc_results <- list()
   
   model_output <- list(
@@ -322,8 +322,8 @@ test_that("CalculateConfidenceRegions() gives region for non-zero-width evidence
   
   n <- 1
   mockery::stub(
-    CalculateConfidenceRegions,
-    ".FindConfidenceInterval",
+    CalculateCredibleRegions,
+    ".FindCredibleInterval",
     function(...) {
       this_interval <- interval[n, c("2.5%", "97.5%")]
       n <<- n + 1
@@ -331,7 +331,7 @@ test_that("CalculateConfidenceRegions() gives region for non-zero-width evidence
     }
   )
   
-  result <- CalculateConfidenceRegions(model_output)
+  result <- CalculateCredibleRegions(model_output)
   
   expect_equal(names(result$intervals), c("Ibuprofen"))
   expect_equal(names(result$regions), c("Ibuprofen"))


### PR DESCRIPTION
There was another bug. If the dataset contains a covariate that only takes the values 0 and 1, this is inferred to be a binary covariate. However, the user can select it to be continuous. In this case, the model didn't run because gemtc made the same inference, and it had not been overridden.

In hindsight we shouldn't have allowed the covariate type to be changed by the user, because the chances that a real dataset would contain a continuous covariate that only ever took the values 0 and 1 is negligible. I doubt anyone will ever use the option.