### PR TITLE
Fix bug

### DIFF
--- a/R/meta_regression/contribution_matrix.R
+++ b/R/meta_regression/contribution_matrix.R
@@ -587,8 +587,8 @@ CheckSingularMatrix <- function(matrix){
   CheckSingularMatrix(t(X_star) %*% solve(V_star) %*% X_star)
   
   A <- solve(t(X_star) %*% solve(V_star) %*% X_star) %*% t(X_star) %*% solve(V_star)
-  A_row2_left <- A[(ncol(X) + 1):(ncol(X) + ncol(X_d)), 1:nrow(X)]
-  A_row3_left <- A[(ncol(X) + ncol(X_d) + 1):(ncol(X) + ncol(X_d) + ncol(X_beta)), 1:nrow(X)]
+  A_row2_left <- A[(nrow(X) + 1):(nrow(X) + ncol(X_d)), 1:nrow(X)]
+  A_row3_left <- A[(nrow(X) + ncol(X_d) + 1):(nrow(X) + ncol(X_d) + ncol(X_beta)), 1:nrow(X)]
   
   if (basic_or_all_parameters == "all") {
     contribution <- Z %*% rbind(A_row2_left, A_row3_left)


### PR DESCRIPTION
The easiest way to see this has worked is to view the matrix itself rather than look at the regression plot. Put a browser() on line 908 of contribution_matrix.R and run `round(contribution_output, digits = 2)`. Compare the exchangeable random effects model on the continuous dataset with the shared or unrelated model. Notice the values in the top left of the matrix are similar. Do the same in dev and you'll see they are all zero in the exchangeable model, which is wrong.