### PR TITLE
MI-78 hide bayesian

### DIFF
--- a/R/bayesian/bayesian_analysis_panel.R
+++ b/R/bayesian/bayesian_analysis_panel.R
@@ -171,7 +171,8 @@ bayesian_analysis_panel_server <- function(
     # 3f. Deviance report
     deviance_report_page_server(
       id = "deviance_report",
-      models = c(model, model_sub)
+      models = c(model, model_sub),
+      models_valid = c(model_valid, model_sub_valid)
     )
 
     # 3g. Model details

--- a/R/bayesian/bayesian_analysis_panel.R
+++ b/R/bayesian/bayesian_analysis_panel.R
@@ -164,7 +164,8 @@ bayesian_analysis_panel_server <- function(
     # 3e. Bayesian result details
     result_details_page_server(
       id = "result_details",
-      models = c(model, model_sub)
+      models = c(model, model_sub),
+      models_valid = c(model_valid, model_sub_valid)
     )
 
     # 3f. Deviance report

--- a/R/bayesian/bayesian_analysis_panel.R
+++ b/R/bayesian/bayesian_analysis_panel.R
@@ -2,6 +2,7 @@
 #' Module UI for the bayesian analysis panel
 #' 
 #' @param id ID of the module
+#' @param page_numbering PageNumbering object for giving each page a unique identifier in the UI
 #' @return Div for the panel
 bayesian_analysis_panel_ui <- function(id, page_numbering) {
   ns <- NS(id)

--- a/R/bayesian/bayesian_analysis_panel.R
+++ b/R/bayesian/bayesian_analysis_panel.R
@@ -36,7 +36,7 @@ bayesian_analysis_panel_ui <- function(id, page_numbering) {
       ),
       tabPanel(
         title = paste0(page_numbering$AddChild(), " Model details"),
-        model_details_panel_ui(id = ns("model_details"), c("all studies", " the sensitivity analysis"), page_numbering)
+        model_details_panel_ui(id = ns("model_details"), c("all studies", "the sensitivity analysis"), page_numbering)
       )
     )
   )
@@ -178,7 +178,8 @@ bayesian_analysis_panel_server <- function(
     # 3g. Model details
     model_details_panel_server(
       id = "model_details",
-      models = c(model, model_sub)
+      models = c(model, model_sub),
+      models_valid = c(model_valid, model_sub_valid)
     )
   })
 }

--- a/R/bayesian/bayesian_analysis_panel.R
+++ b/R/bayesian/bayesian_analysis_panel.R
@@ -146,7 +146,9 @@ bayesian_analysis_panel_server <- function(
       freq_all = freq_all,
       freq_sub = freq_sub,
       bugsnetdt = bugsnetdt,
-      bugsnetdt_sub = bugsnetdt_sub
+      bugsnetdt_sub = bugsnetdt_sub,
+      model_valid = model_valid,
+      model_sub_valid = model_sub_valid
     )
 
     # 3d. Nodesplit model

--- a/R/bayesian/bayesian_analysis_panel.R
+++ b/R/bayesian/bayesian_analysis_panel.R
@@ -117,14 +117,17 @@ bayesian_analysis_panel_server <- function(
     
     model <- forest_plots_reactives$model
     model_sub <- forest_plots_reactives$model_sub
-
+    model_valid <- forest_plots_reactives$model_valid
+    model_sub_valid <- forest_plots_reactives$model_sub_valid
 
     # 3b. Comparison of all treatment pairs
     bayesian_treatment_comparisons_page_server(
       id = "treatment_comparisons",
       model = model,
       model_sub = model_sub,
-      outcome_measure = outcome_measure
+      outcome_measure = outcome_measure,
+      model_valid = model_valid,
+      model_sub_valid = model_sub_valid
     )
 
     # 3c. Ranking Panel

--- a/R/bayesian/deviance/deviance_report_page.R
+++ b/R/bayesian/deviance/deviance_report_page.R
@@ -2,7 +2,7 @@
 #' Module UI for the deviance report page.
 #' 
 #' @param id ID of the module.
-#' @param item_names Vector of item names to be shown side-by-side in the page.
+#' @param item_names Vector of analysis titles to be shown side-by-side in the page.
 #' @return Div for the page
 deviance_report_page_ui <- function(id, item_names) {
   ns <- NS(id)

--- a/R/bayesian/deviance/deviance_report_page.R
+++ b/R/bayesian/deviance/deviance_report_page.R
@@ -136,10 +136,11 @@ deviance_report_page_ui <- function(id, item_names) {
 
 #' Module server for the deviance report page.
 #' 
-#' @param id ID of the module
+#' @param id ID of the module.
 #' @param models Vector of reactives containing bayesian meta-analyses.
+#' @param models_valid Vector of reactives containing whether each model is valid.
 #' @param package "gemtc" (default) or "bnma".
-deviance_report_page_server <- function(id, models, package = "gemtc") {
+deviance_report_page_server <- function(id, models, models_valid, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
 
     output$package <- reactive(paste0("{", package, "}"))
@@ -155,14 +156,10 @@ deviance_report_page_server <- function(id, models, package = "gemtc") {
     outputOptions(x = output, name = "model_type", suspendWhenHidden = FALSE)
     
     # Create server for each model
-    index <- 0
     sapply(
-      models,
-      function(mod) {
-        deviance_report_panel_server(id = as.character(index), model = mod, package = package)
-        # Update the index variable in the outer scope with <<-
-        # This updates the variable defined above the `sapply` call instead of creating a new variable with the same name within this inner function
-        index <<- index + 1
+      1:length(models),
+      function(index) {
+        deviance_report_panel_server(id = as.character(index - 1), model = models[index][[1]], model_valid = models_valid[index][[1]], package = package)
       }
     )
   })

--- a/R/bayesian/deviance/deviance_report_page.R
+++ b/R/bayesian/deviance/deviance_report_page.R
@@ -159,7 +159,7 @@ deviance_report_page_server <- function(id, models, models_valid, package = "gem
     sapply(
       1:length(models),
       function(index) {
-        deviance_report_panel_server(id = as.character(index - 1), model = models[index][[1]], model_valid = models_valid[index][[1]], package = package)
+        deviance_report_panel_server(id = as.character(index - 1), model = models[[index]], model_valid = models_valid[[index]], package = package)
       }
     )
   })

--- a/R/bayesian/deviance/deviance_report_page.R
+++ b/R/bayesian/deviance/deviance_report_page.R
@@ -7,7 +7,9 @@
 deviance_report_page_ui <- function(id, item_names) {
   ns <- NS(id)
   
-  # Matrix containing plots for named items
+  # Matrix containing ui items:
+  # - Deviance plots
+  # - Invalid model notification
   divs <- sapply(
     1:length(item_names),
     function(index) {

--- a/R/bayesian/deviance/deviance_report_page.R
+++ b/R/bayesian/deviance/deviance_report_page.R
@@ -19,11 +19,6 @@ deviance_report_page_ui <- function(id, item_names) {
   
   # Main UI
   div(
-    helpText(
-      "Please note: if you change the selections on the sidebar,
-      you will need to re-run the primary and/or sensitivity analysis from the 'Forest Plot' page."
-    ),
-    
     conditionalPanel(
       condition = "output.model_type != 'consistency'",
       ns = ns,

--- a/R/bayesian/deviance/deviance_report_page.R
+++ b/R/bayesian/deviance/deviance_report_page.R
@@ -8,15 +8,10 @@ deviance_report_page_ui <- function(id, item_names) {
   ns <- NS(id)
   
   # Matrix containing plots for named items
-  index <- 0
   divs <- sapply(
-    item_names,
-    function(name) {
-      div <- deviance_report_panel_ui(id = ns(as.character(index)), item_name = name)
-      # Update the index variable in the outer scope with <<-
-      # This updates the variable defined above the `sapply` call instead of creating a new variable with the same name within this inner function
-      index <<- index + 1
-      return(div)
+    1:length(item_names),
+    function(index) {
+      return(deviance_report_panel_ui(id = ns(glue::glue("deviance_{index}")), item_name = item_names[index]))
     }
   )
   
@@ -42,11 +37,12 @@ deviance_report_page_ui <- function(id, item_names) {
       do.call(
         fluidRow,
         lapply(
-          item_names,
-          function(name) {
+          1:length(item_names),
+          function(index) {
             column(
               width = 12 / length(item_names),
-              divs["residual", name]
+              divs["model_invalid", index],
+              divs["residual", index]
             )
           }
         )
@@ -72,11 +68,11 @@ deviance_report_page_ui <- function(id, item_names) {
     do.call(
       fluidRow,
       lapply(
-        item_names,
-        function(name) {
+        1:length(item_names),
+        function(index) {
           column(
             width = 12 / length(item_names),
-            divs["per_arm", name]
+            divs["per_arm", index]
           )
         }
       )
@@ -100,11 +96,11 @@ deviance_report_page_ui <- function(id, item_names) {
     do.call(
       fluidRow,
       lapply(
-        item_names,
-        function(name) {
+        1:length(item_names),
+        function(index) {
           column(
             width = 12 / length(item_names),
-            divs["leverage", name]
+            divs["leverage", index]
           )
         }
       )
@@ -159,7 +155,7 @@ deviance_report_page_server <- function(id, models, models_valid, package = "gem
     sapply(
       1:length(models),
       function(index) {
-        deviance_report_panel_server(id = as.character(index - 1), model = models[[index]], model_valid = models_valid[[index]], package = package)
+        deviance_report_panel_server(glue::glue("deviance_{index}"), model = models[[index]], model_valid = models_valid[[index]], package = package)
       }
     )
   })

--- a/R/bayesian/deviance/deviance_report_panel.R
+++ b/R/bayesian/deviance/deviance_report_panel.R
@@ -27,14 +27,18 @@ deviance_report_panel_ui <- function(id, item_name) {
 
 #' Module server for the deviance report panel.
 #' 
-#' @param id ID of the module
+#' @param id ID of the module.
 #' @param model Reactive containing bayesian meta-analysis.
 #' @param package "gemtc" (default) or "bnma".
-deviance_report_panel_server <- function(id, model, package = "gemtc") {
+#' @param model_valid Reactive containing whether the model is valid.
+deviance_report_panel_server <- function(id, model, model_valid, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
 
     # Residual deviance from NMA model and UME inconsistency model
     output$dev_scat <- renderPlotly({
+      if (!model_valid()) {
+        return()
+      }
       if (package == "gemtc") {
         return(scat_plot(model())$p)
       } else if (package == "bnma") {
@@ -44,11 +48,17 @@ deviance_report_panel_server <- function(id, model, package = "gemtc") {
 
     # Per-arm residual deviance
     output$per_arm <- renderPlotly({
+      if (!model_valid()) {
+        return()
+      }
       stemplot(model(), package = package)
     })
 
     # Leverage plot
     output$leverage <- renderPlotly({
+      if (!model_valid()) {
+        return()
+      }
       levplot(model(), package = package)
     })
   })

--- a/R/bayesian/deviance/deviance_report_panel.R
+++ b/R/bayesian/deviance/deviance_report_panel.R
@@ -3,7 +3,8 @@
 #' 
 #' @param id ID of the module
 #' @param item_name Name of this deviance report item.
-#' @return List of divs containing the plots. Named "residual", "per_arm", and "leverage".
+#' @return List of divs containing the plots and an invalid model notification.
+#' Named "residual", "per_arm", and "leverage".
 deviance_report_panel_ui <- function(id, item_name) {
   ns <- NS(id)
   return(

--- a/R/bayesian/deviance/deviance_report_panel.R
+++ b/R/bayesian/deviance/deviance_report_panel.R
@@ -41,7 +41,7 @@ deviance_report_panel_server <- function(id, model, model_valid, package = "gemt
 
     # Residual deviance from NMA model and UME inconsistency model
     output$dev_scat <- renderPlotly({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       if (package == "gemtc") {
@@ -53,7 +53,7 @@ deviance_report_panel_server <- function(id, model, model_valid, package = "gemt
 
     # Per-arm residual deviance
     output$per_arm <- renderPlotly({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       stemplot(model(), package = package)
@@ -61,7 +61,7 @@ deviance_report_panel_server <- function(id, model, model_valid, package = "gemt
 
     # Leverage plot
     output$leverage <- renderPlotly({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       levplot(model(), package = package)

--- a/R/bayesian/deviance/deviance_report_panel.R
+++ b/R/bayesian/deviance/deviance_report_panel.R
@@ -8,6 +8,9 @@ deviance_report_panel_ui <- function(id, item_name) {
   ns <- NS(id)
   return(
     list(
+      model_invalid = div(
+        invalid_model_panel_ui(id = ns("model_invalid"))
+      ),
       residual = div(
         p(tags$strong(glue::glue("Residual deviance from NMA model and UME inconsistency model for {item_name}"))),
         plotlyOutput(outputId = ns("dev_scat"))
@@ -33,6 +36,8 @@ deviance_report_panel_ui <- function(id, item_name) {
 #' @param model_valid Reactive containing whether the model is valid.
 deviance_report_panel_server <- function(id, model, model_valid, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
+    
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
 
     # Residual deviance from NMA model and UME inconsistency model
     output$dev_scat <- renderPlotly({

--- a/R/bayesian/forest_plot/forest_plot_page.R
+++ b/R/bayesian/forest_plot/forest_plot_page.R
@@ -69,7 +69,11 @@ bayesian_forest_plots_page_ui <- function(id) {
 #' @param reference_alter Reactive containing the name of the reference treatment for the sensitivity
 #'  analysis accounting for if the chosen reference treatment has been excluded
 #'
-#' @return List of reactives: "model" contains the full bayesian meta-analysis, "model_sub" contains the bayesian meta-analysis with studies excluded
+#' @return List of reactives:
+#' - "model" contains the full bayesian meta-analysis
+#' - "model_sub" contains the bayesian meta-analysis with studies excluded
+#' - "model_valid" contains the validity of the full bayesian meta-analysis, NULL if the analysis has not been run yet
+#' - "model_sub_valid" contains the validity of the bayesian meta-analysis with studies excluded, NULL if the analysis has not been run yet
 bayesian_forest_plots_page_server <- function(
     id,
     data,

--- a/R/bayesian/forest_plot/forest_plot_page.R
+++ b/R/bayesian/forest_plot/forest_plot_page.R
@@ -109,6 +109,80 @@ bayesian_forest_plots_page_server <- function(
                      outcome_measure(), model_effects(), reference_alter()$ref_sub)
     })
     
+    
+    
+    
+    
+    
+    
+    
+    
+    model_valid = reactiveVal(FALSE)
+    model_sub_valid = reactiveVal(FALSE)
+    parameter_matcher <- ParameterMatcher$new()
+    parameter_matcher_sub <- ParameterMatcher$new()
+    
+    observe({
+      model_valid(
+        parameter_matcher$Matches(
+          data = data(),
+          treatment_df = treatment_df(),
+          metaoutcome = metaoutcome(),
+          outcome_measure = outcome_measure(),
+          model_effects = model_effects(),
+          ref = reference_alter()$ref_all
+        )
+      )
+    })
+    
+    observe({
+      model_sub_valid(
+        parameter_matcher_sub$Matches(
+          data = sensitivity_data(),
+          treatment_df = sensitivity_treatment_df(),
+          metaoutcome = metaoutcome(),
+          outcome_measure = outcome_measure(),
+          model_effects = model_effects(),
+          ref = reference_alter()$ref_sub
+        )
+      )
+    })
+    
+    observe({
+      parameter_matcher$SetParameters(
+        data = data(),
+        treatment_df = treatment_df(),
+        metaoutcome = metaoutcome(),
+        outcome_measure = outcome_measure(),
+        model_effects = model_effects(),
+        ref = reference_alter()$ref_all
+      )
+      model_valid(TRUE)
+    }) |> bindEvent(model())
+    
+    observe({
+      parameter_matcher_sub$SetParameters(
+        data = sensitivity_data(),
+        treatment_df = sensitivity_treatment_df(),
+        metaoutcome = metaoutcome(),
+        outcome_measure = outcome_measure(),
+        model_effects = model_effects(),
+        ref = reference_alter()$ref_sub
+      )
+      model_sub_valid(TRUE)
+    }) |> bindEvent(model_sub())
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
     # Create forest plot and associated statistics
     
     bayesian_forest_plot_plus_stats_server(
@@ -117,7 +191,8 @@ bayesian_forest_plots_page_server <- function(
       analysis_type = "Full",
       metaoutcome = metaoutcome,
       outcome_measure = outcome_measure,
-      bugsnetdt = bugsnetdt
+      bugsnetdt = bugsnetdt,
+      model_valid = model_valid
     )
     
     bayesian_forest_plot_plus_stats_server(
@@ -126,7 +201,8 @@ bayesian_forest_plots_page_server <- function(
       analysis_type = "Sub",
       metaoutcome = metaoutcome,
       outcome_measure = outcome_measure,
-      bugsnetdt = bugsnetdt_sub
+      bugsnetdt = bugsnetdt_sub,
+      model_valid = model_sub_valid
     )
     
 

--- a/R/bayesian/forest_plot/forest_plot_page.R
+++ b/R/bayesian/forest_plot/forest_plot_page.R
@@ -109,11 +109,13 @@ bayesian_forest_plots_page_server <- function(
                      outcome_measure(), model_effects(), reference_alter()$ref_sub)
     })
     
+    # ReactiveVals contain validity state of the model. NULL if the model has not yet been run.
     model_valid = reactiveVal(NULL)
     model_sub_valid = reactiveVal(NULL)
     parameter_matcher <- ParameterMatcher$new()
     parameter_matcher_sub <- ParameterMatcher$new()
     
+    # Set validity when model input change
     observe({
       # Only assess the validity once the model has been run the first time
       if (is.null(model_valid())) {
@@ -132,6 +134,7 @@ bayesian_forest_plots_page_server <- function(
       )
     })
     
+    # Set validity when model input change
     observe({
       # Only assess the validity once the model has been run the first time
       if (is.null(model_sub_valid())) {
@@ -150,6 +153,7 @@ bayesian_forest_plots_page_server <- function(
       )
     })
     
+    # Record inputs when model run
     observe({
       parameter_matcher$SetParameters(
         data = data(),
@@ -162,6 +166,7 @@ bayesian_forest_plots_page_server <- function(
       model_valid(TRUE)
     }) |> bindEvent(model())
     
+    # Record inputs when model run
     observe({
       parameter_matcher_sub$SetParameters(
         data = sensitivity_data(),

--- a/R/bayesian/forest_plot/forest_plot_page.R
+++ b/R/bayesian/forest_plot/forest_plot_page.R
@@ -109,14 +109,6 @@ bayesian_forest_plots_page_server <- function(
                      outcome_measure(), model_effects(), reference_alter()$ref_sub)
     })
     
-    
-    
-    
-    
-    
-    
-    
-    
     model_valid = reactiveVal(FALSE)
     model_sub_valid = reactiveVal(FALSE)
     parameter_matcher <- ParameterMatcher$new()
@@ -173,16 +165,6 @@ bayesian_forest_plots_page_server <- function(
     }) |> bindEvent(model_sub())
     
     
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
     # Create forest plot and associated statistics
     
     bayesian_forest_plot_plus_stats_server(
@@ -215,7 +197,9 @@ bayesian_forest_plots_page_server <- function(
     return(
       list(
         model = model,
-        model_sub = model_sub
+        model_sub = model_sub,
+        model_valid = model_valid,
+        model_sub_valid = model_sub_valid
       )
     )
   })

--- a/R/bayesian/forest_plot/forest_plot_page.R
+++ b/R/bayesian/forest_plot/forest_plot_page.R
@@ -109,12 +109,17 @@ bayesian_forest_plots_page_server <- function(
                      outcome_measure(), model_effects(), reference_alter()$ref_sub)
     })
     
-    model_valid = reactiveVal(FALSE)
-    model_sub_valid = reactiveVal(FALSE)
+    model_valid = reactiveVal(NULL)
+    model_sub_valid = reactiveVal(NULL)
     parameter_matcher <- ParameterMatcher$new()
     parameter_matcher_sub <- ParameterMatcher$new()
     
     observe({
+      # Only assess the validity once the model has been run the first time
+      if (is.null(model_valid())) {
+        return()
+      }
+      
       model_valid(
         parameter_matcher$Matches(
           data = data(),
@@ -128,6 +133,11 @@ bayesian_forest_plots_page_server <- function(
     })
     
     observe({
+      # Only assess the validity once the model has been run the first time
+      if (is.null(model_sub_valid())) {
+        return()
+      }
+      
       model_sub_valid(
         parameter_matcher_sub$Matches(
           data = sensitivity_data(),

--- a/R/bayesian/forest_plot/forest_plot_page.R
+++ b/R/bayesian/forest_plot/forest_plot_page.R
@@ -128,7 +128,6 @@ bayesian_forest_plots_page_server <- function(
       
       model_valid(
         parameter_matcher$Matches(
-          data = data(),
           treatment_df = treatment_df(),
           metaoutcome = metaoutcome(),
           outcome_measure = outcome_measure(),
@@ -147,7 +146,6 @@ bayesian_forest_plots_page_server <- function(
       
       model_sub_valid(
         parameter_matcher_sub$Matches(
-          data = sensitivity_data(),
           treatment_df = sensitivity_treatment_df(),
           metaoutcome = metaoutcome(),
           outcome_measure = outcome_measure(),
@@ -157,10 +155,19 @@ bayesian_forest_plots_page_server <- function(
       )
     })
     
+    # Clear validity when data changes
+    observe({
+      model_valid(NULL)
+    }) |> bindEvent(data())
+    
+    # Clear validity when data changes
+    observe({
+      model_sub_valid(NULL)
+    }) |> bindEvent(sensitivity_data())
+    
     # Record inputs when model run
     observe({
       parameter_matcher$SetParameters(
-        data = data(),
         treatment_df = treatment_df(),
         metaoutcome = metaoutcome(),
         outcome_measure = outcome_measure(),
@@ -173,7 +180,6 @@ bayesian_forest_plots_page_server <- function(
     # Record inputs when model run
     observe({
       parameter_matcher_sub$SetParameters(
-        data = sensitivity_data(),
         treatment_df = sensitivity_treatment_df(),
         metaoutcome = metaoutcome(),
         outcome_measure = outcome_measure(),

--- a/R/bayesian/forest_plot/forest_plot_page.R
+++ b/R/bayesian/forest_plot/forest_plot_page.R
@@ -27,14 +27,12 @@ bayesian_forest_plots_page_ui <- function(id) {
         width = 6,
         align = "center",
         p(tags$strong("Results for all studies")),
-        p("Please click the button below to run Bayesian analysis for all studies, and after each time when you change the radiobutton selections."),
         actionButton(inputId = ns("baye_do"), label = "Click here to run the main analysis for all studies")
       ),
       column(
         width = 6,
         align = "center",
         p(tags$strong("Results with selected studies excluded")),
-        p("Please click the button below to run each time after you finish the selection of studies, or change the radiobutton selections."),
         actionButton(inputId = ns("sub_do"), label = "Click here to run the sensitivity analysis")
       )
     ),

--- a/R/bayesian/forest_plot/forest_plot_plus_stats.R
+++ b/R/bayesian/forest_plot/forest_plot_plus_stats.R
@@ -71,7 +71,7 @@ bayesian_forest_plot_plus_stats_server <- function(
     invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
     
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id="download_plot")
       } else {
         shinyjs::enable(id="download_plot")
@@ -98,7 +98,7 @@ bayesian_forest_plot_plus_stats_server <- function(
 
     # Forest plot for all studies
     output$forest_plot <- renderPlot({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       
@@ -121,7 +121,7 @@ bayesian_forest_plot_plus_stats_server <- function(
       rownames = TRUE,
       colnames = FALSE,
       {
-        if (!model_valid()) {
+        if (is.null(model_valid()) || !model_valid()) {
           return()
         }
         model_output()$dic
@@ -130,7 +130,7 @@ bayesian_forest_plot_plus_stats_server <- function(
     
     # Tau all studies
     output$tau_text <-renderText({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       CreateTauSentence(model_output(), outcome_measure())
@@ -204,8 +204,10 @@ bayesian_forest_plot_plus_stats_baseline_risk_server <- function(
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
+    
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id="download_plot")
       } else {
         shinyjs::enable(id="download_plot")
@@ -217,8 +219,7 @@ bayesian_forest_plot_plus_stats_baseline_risk_server <- function(
     
     # Forest plot for all studies
     output$forest_plot <- renderPlot({
-      if (!model_valid()) {
-        mtext("Please rerun model", side = 3, adj = 0, cex = 2)
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       
@@ -231,7 +232,7 @@ bayesian_forest_plot_plus_stats_baseline_risk_server <- function(
       rownames = TRUE,
       colnames = FALSE,
       {
-        if (!model_valid()) {
+        if (is.null(model_valid()) || !model_valid()) {
           return()
         }
         BaselineRiskDicTable(model_reactive())
@@ -240,7 +241,7 @@ bayesian_forest_plot_plus_stats_baseline_risk_server <- function(
     
     # Tau all studies
     output$tau_text <-renderText({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       CreateTauSentence(

--- a/R/bayesian/forest_plot/forest_plot_plus_stats.R
+++ b/R/bayesian/forest_plot/forest_plot_plus_stats.R
@@ -54,6 +54,7 @@ bayesian_forest_plot_plus_stats_ui <- function(id) {
 #' @param metaoutcome Reactive containing meta analysis outcome: "Continuous" or "Binary"
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD", "SMD", "OR, "RR", or "RD"
 #' @param bugsnetdt Reactive containing bugsnet meta-analysis
+#' @param model_valid Reactive containing whether the model is valid
 bayesian_forest_plot_plus_stats_server <- function(
     id,
     model_output,
@@ -98,6 +99,7 @@ bayesian_forest_plot_plus_stats_server <- function(
         mtext("Please rerun model", side = 3, adj = 0, cex = 2)
         return()
       }
+      
       CreateForestPlot(model_output(), metaoutcome(), input$axis_min, input$axis_max)
       title(paste(ifelse(analysis_type == "Full", "All studies:", 
                          ifelse(analysis_type == "Sub", "Results with studies excluded:",
@@ -112,12 +114,16 @@ bayesian_forest_plot_plus_stats_server <- function(
     })
     
     # DIC table for all studies
-    output$dic <- renderTable ({
-      if (!model_valid()) {
-        return()
+    output$dic <- renderTable (
+      digits = 3,
+      rownames = TRUE,
+      colnames = FALSE,
+      {
+        if (!model_valid()) {
+          return()
+        }
+        model_output()$dic
       }
-      model_output()$dic
-    }, digits=3, rownames=TRUE, colnames=FALSE
     )
     
     # Tau all studies
@@ -157,14 +163,16 @@ bayesian_forest_plot_plus_stats_server <- function(
     # Interactive UI - forest plot
     output$bayesian_forest_plot <- renderUI({
       shinycssloaders::withSpinner(
+        type = 6,
         plotOutput(
-        outputId = ns("forest_plot"),
-        width="630px",
-        height = BayesPixels(
-          as.numeric(bugsnet_sumtb(bugsnetdt(), metaoutcome())$Value[1]),
-          title = TRUE
+          outputId = ns("forest_plot"),
+          width="630px",
+          height = BayesPixels(
+            as.numeric(bugsnet_sumtb(bugsnetdt(), metaoutcome())$Value[1]),
+            title = TRUE
+          )
         )
-      ), type = 6)
+      )
     })
     
   })
@@ -182,37 +190,61 @@ bayesian_forest_plot_plus_stats_server <- function(
 #' @param metaoutcome Reactive containing meta analysis outcome: "Continuous" or "Binary"
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD" or "OR"
 #' @param bugsnetdt Reactive containing bugsnet meta-analysis
+#' @param model_valid Reactive containing whether the model is valid
 bayesian_forest_plot_plus_stats_baseline_risk_server <- function(
     id,
     model_reactive,
     metaoutcome,
     outcome_measure,
-    bugsnetdt
+    bugsnetdt,
+    model_valid = reactiveVal(TRUE)
 ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+    
+    observe({
+      if (!model_valid()) {
+        shinyjs::disable(id="download_plot")
+      } else {
+        shinyjs::enable(id="download_plot")
+      }
+    })
 
     output$package <- reactive({"bnma"})
     outputOptions(x = output, name = "package", suspendWhenHidden = FALSE)
     
     # Forest plot for all studies
     output$forest_plot <- renderPlot({
+      if (!model_valid()) {
+        mtext("Please rerun model", side = 3, adj = 0, cex = 2)
+        return()
+      }
+      
       bnma::network.forest.plot(model_reactive(), only.reference.treatment = TRUE)
     }) 
     
-    observe({
-      model_reactive()
-      # DIC table for all studies
-      output$dic <- renderTable ({
+    # DIC table for all studies
+    output$dic <- renderTable (
+      digits = 3,
+      rownames = TRUE,
+      colnames = FALSE,
+      {
+        if (!model_valid()) {
+          return()
+        }
         BaselineRiskDicTable(model_reactive())
-      }, digits=3, rownames=TRUE, colnames=FALSE)
-      # Tau all studies
-      output$tau_text <-renderText({
-        CreateTauSentence(
-          FormatForCreateTauSentence(model_reactive()),
-          outcome_measure()
-        )
-      })
+      }
+    )
+    
+    # Tau all studies
+    output$tau_text <-renderText({
+      if (!model_valid()) {
+        return()
+      }
+      CreateTauSentence(
+        FormatForCreateTauSentence(model_reactive()),
+        outcome_measure()
+      )
     })
     
     output$download_plot <- downloadHandler(
@@ -238,6 +270,7 @@ bayesian_forest_plot_plus_stats_baseline_risk_server <- function(
     # Interactive UI - forest plot
     output$bayesian_forest_plot <- renderUI({
       shinycssloaders::withSpinner(
+        type = 6,
         plotOutput(
           outputId = ns("forest_plot"),
           width="630px",
@@ -245,7 +278,8 @@ bayesian_forest_plot_plus_stats_baseline_risk_server <- function(
             as.numeric(bugsnet_sumtb(bugsnetdt(), metaoutcome())$Value[1]),
             title = FALSE
           )
-        ), type = 6)
+        )
+      )
     })
 
   })

--- a/R/bayesian/forest_plot/forest_plot_plus_stats.R
+++ b/R/bayesian/forest_plot/forest_plot_plus_stats.R
@@ -6,6 +6,7 @@
 bayesian_forest_plot_plus_stats_ui <- function(id) {
   ns <- NS(id)
   div(
+    invalid_model_panel_ui(id = ns("model_invalid")),
     shinycssloaders::withSpinner(
       uiOutput(outputId = ns("bayesian_forest_plot")),
       type = 6
@@ -67,6 +68,8 @@ bayesian_forest_plot_plus_stats_server <- function(
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
+    
     observe({
       if (!model_valid()) {
         shinyjs::disable(id="download_plot")
@@ -96,7 +99,6 @@ bayesian_forest_plot_plus_stats_server <- function(
     # Forest plot for all studies
     output$forest_plot <- renderPlot({
       if (!model_valid()) {
-        mtext("Please rerun model", side = 3, adj = 0, cex = 2)
         return()
       }
       

--- a/R/bayesian/invalid_model_panel.R
+++ b/R/bayesian/invalid_model_panel.R
@@ -18,16 +18,17 @@ invalid_model_panel_server <- function(id, model_valid) {
     id,
     function(input, output, session) {
       output$invalid_model <- renderUI({
-        if (model_valid()) {
-          return()
-        } else {
+        if (is.null(model_valid())) {
           return(
-            div(
-              h3("Please rerun model"),
-              style = ""
-            )
+            h3("Please run model")
+          )
+        } else if (!model_valid()) {
+          return(
+            h3("Please rerun model")
           )
         }
+        
+        return()
       })
     }
   )

--- a/R/bayesian/invalid_model_panel.R
+++ b/R/bayesian/invalid_model_panel.R
@@ -1,0 +1,34 @@
+
+#' Module UI for the invalid model panel.
+#' 
+#' @param id ID of the module.
+#' @return uiOutput for the panel.
+invalid_model_panel_ui <- function(id) {
+  ns <- NS(id)
+  return(uiOutput(outputId = ns("invalid_model")))
+}
+
+
+#' Module server for the nodesplit model panel.
+#' 
+#' @param id ID of the module
+#' @param model_valid Reactive containing whether the model is valid.
+invalid_model_panel_server <- function(id, model_valid) {
+  moduleServer(
+    id,
+    function(input, output, session) {
+      output$invalid_model <- renderUI({
+        if (model_valid()) {
+          return()
+        } else {
+          return(
+            div(
+              h3("Please rerun model"),
+              style = ""
+            )
+          )
+        }
+      })
+    }
+  )
+}

--- a/R/bayesian/model_details_panel.R
+++ b/R/bayesian/model_details_panel.R
@@ -128,7 +128,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
     invalid_model_panel_server(id = "model_invalid_3", model_valid = main_model_valid)
     
     observe({
-      if (!main_model_valid()) {
+      if (is.null(main_model_valid()) || !main_model_valid()) {
         fn <- shinyjs::disable
       } else {
         fn <- shinyjs::enable
@@ -147,7 +147,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
 
     # 3g-1 Model codes
     output$code <- renderPrint({
-      if (!main_model_valid()) {
+      if (is.null(main_model_valid()) || !main_model_valid()) {
         return()
       }
       if (package == "gemtc") {
@@ -172,7 +172,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
     
     # 3g-2 Initial values
     inits <- reactive({
-      if (!main_model_valid()) {
+      if (is.null(main_model_valid()) || !main_model_valid()) {
         return()
       }
       if (package == "gemtc") {
@@ -194,7 +194,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
     # 3g-3 Chain data.
 
     samples <- reactive({
-      if (!main_model_valid()) {
+      if (is.null(main_model_valid()) || !main_model_valid()) {
         return()
       }
       if (package == "gemtc") {
@@ -215,7 +215,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
     
     model_type <- reactive({
       for (index in 1:length(models)) {
-        if (!models_valid[[index]]()) {
+        if (is.null(models_valid[[index]]()) || !models_valid[[index]]()) {
           next
         }
         if (package == "gemtc") {
@@ -244,7 +244,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
         
         # NMA consistency model
         output[[glue::glue("dev_{index}")]] <- renderPrint({
-          if (!mod_valid()) {
+          if (is.null(mod_valid()) || !mod_valid()) {
             return()
           }
           if (package == "gemtc") {
@@ -256,7 +256,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
         
         # UME inconsistency model
         output[[glue::glue("dev_ume_{index}")]] <- renderText({
-          if (!mod_valid()) {
+          if (is.null(mod_valid()) || !mod_valid()) {
             return()
           }
           if (model_type() != "consistency") {

--- a/R/bayesian/model_details_panel.R
+++ b/R/bayesian/model_details_panel.R
@@ -2,6 +2,8 @@
 #' Module UI for the model details panel
 #' 
 #' @param id ID of the module
+#' @param item_names Vector of analysis titles to be shown side-by-side in the page.
+#' @param page_numbering PageNumbering object for giving each page a unique identifier in the UI
 #' @return Div for the panel
 model_details_panel_ui <- function(id, item_names, page_numbering) {
   ns <- NS(id)
@@ -113,8 +115,8 @@ model_details_panel_ui <- function(id, item_names, page_numbering) {
 #' Module server for the model details panel.
 #' 
 #' @param id ID of the module
-#' @param model Reactive containing bayesian meta-analysis for all studies
-#' @param model_sub Reactive containing meta-analysis with studies excluded
+#' @param models Vector of reactives containing bayesian meta-analyses.
+#' @param models_valid Vector of reactives containing whether each model is valid.
 #' @param package "gemtc" (default) or "bnma".
 model_details_panel_server <- function(id, models, models_valid, package = "gemtc") {
   moduleServer(id, function(input, output, session) {

--- a/R/bayesian/model_details_panel.R
+++ b/R/bayesian/model_details_panel.R
@@ -130,7 +130,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
     invalid_model_panel_server(id = "model_invalid_3", model_valid = main_model_valid)
     
     observe({
-      # Get either enble or disable function to apply to relevant UI elements
+      # Get either enable or disable function to apply to relevant UI elements
       if (is.null(main_model_valid()) || !main_model_valid()) {
         fn <- shinyjs::disable
       } else {

--- a/R/bayesian/model_details_panel.R
+++ b/R/bayesian/model_details_panel.R
@@ -32,10 +32,6 @@ model_details_panel_ui <- function(id, item_names, page_numbering) {
   )
   
   ui = div(
-    helpText(
-      "Please note: if you change the selections on the sidebar,
-      you will need to re-run the primary and/or sensitivity analysis from the 'Forest Plot' page."
-    ),
     tabsetPanel(
       tabPanel(
         title = paste0(page_numbering$AddChild(), " Model codes"),

--- a/R/bayesian/model_details_panel.R
+++ b/R/bayesian/model_details_panel.R
@@ -37,12 +37,14 @@ model_details_panel_ui <- function(id, item_names, page_numbering) {
     tabsetPanel(
       tabPanel(
         title = paste0(page_numbering$AddChild(), " Model codes"),
+        invalid_model_panel_ui(id = ns("model_invalid_1")),
         p(tags$strong("Model codes for analysis of all studies")),
         downloadButton(outputId = ns('download_code')),
         verbatimTextOutput(outputId = ns("code"))
       ),
       tabPanel(
         title = paste0(page_numbering$AddChild(), " Initial values"),
+        invalid_model_panel_ui(id = ns("model_invalid_2")),
         p(tags$strong("Initial values")),
         downloadButton(outputId = ns('download_inits_1'), "Download initial values for chain 1"),
         downloadButton(outputId = ns('download_inits_2'), "Download initial values for chain 2"),
@@ -52,6 +54,7 @@ model_details_panel_ui <- function(id, item_names, page_numbering) {
       ),
       tabPanel(
         title = paste0(page_numbering$AddChild(), " Download simulations"),
+        invalid_model_panel_ui(id = ns("model_invalid_3")),
         p(tags$strong("Download simulated data")),
         downloadButton(outputId = ns('download_data1'), "Download data from chain 1"),
         br(),
@@ -68,10 +71,12 @@ model_details_panel_ui <- function(id, item_names, page_numbering) {
         do.call(
           fluidRow,
           lapply(
-            item_names,
-            function(name) {
+            1:length(item_names),
+            function(index) {
+              name <- item_names[[index]]
               column(
                 width = 12 / length(item_names),
+                invalid_model_panel_ui(id = ns(glue::glue("model_invalid_4_{index}"))),
                 divs["deviance", name]
               )
             }
@@ -117,6 +122,10 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
     
     main_model <- models[[1]]
     main_model_valid <- models_valid[[1]]
+    
+    invalid_model_panel_server(id = "model_invalid_1", model_valid = main_model_valid)
+    invalid_model_panel_server(id = "model_invalid_2", model_valid = main_model_valid)
+    invalid_model_panel_server(id = "model_invalid_3", model_valid = main_model_valid)
     
     observe({
       if (!main_model_valid()) {
@@ -230,6 +239,9 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
       function(index) {
         mod = models[[index]]
         mod_valid <- models_valid[[index]]
+        
+        invalid_model_panel_server(id = glue::glue("model_invalid_4_{index}"), model_valid = mod_valid)
+        
         # NMA consistency model
         output[[glue::glue("dev_{index}")]] <- renderPrint({
           if (!mod_valid()) {

--- a/R/bayesian/model_details_panel.R
+++ b/R/bayesian/model_details_panel.R
@@ -128,19 +128,21 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
     invalid_model_panel_server(id = "model_invalid_3", model_valid = main_model_valid)
     
     observe({
+      # Get either enble or disable function to apply to relevant UI elements
       if (is.null(main_model_valid()) || !main_model_valid()) {
         fn <- shinyjs::disable
       } else {
         fn <- shinyjs::enable
       }
       
-      fn(id=glue::glue("download_code"))
+      # Apply enable or disable function
+      fn(id = glue::glue("download_code"))
       
       sapply(
         1:4,
         function(index) {
-          fn(id=glue::glue("download_inits_{index}"))
-          fn(id=glue::glue("download_data{index}"))
+          fn(id = glue::glue("download_inits_{index}"))
+          fn(id = glue::glue("download_data{index}"))
         }
       )
     })
@@ -184,6 +186,7 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
     
     output$inits <- renderPrint({inits()})
     
+    # Download handlers for download buttons
     sapply(
       1:4,
       function(index) {
@@ -203,7 +206,8 @@ model_details_panel_server <- function(id, models, models_valid, package = "gemt
         return(main_model()$samples)
       }
     })
-
+    
+    # Download handlers for download buttons
     sapply(
       1:4,
       function(index) {

--- a/R/bayesian/nodesplit/nodesplit_page.R
+++ b/R/bayesian/nodesplit/nodesplit_page.R
@@ -6,10 +6,6 @@
 nodesplit_page_ui <- function(id) {
   ns <- NS(id)
   div(
-    helpText(
-      "Please note: if you change the selections on the sidebar,
-      you will need to re-run the primary and/or sensitivity analysis from the 'Forest Plot' page."
-    ),
     p(
       "Please note: This may take more than 10 minutes depending on the number of treatment options. The node splitting option for
       the Bayesian analysis is highly numerically intensive and using it on the app can cause the app to disconnect in some circumstances.  We have produced a",

--- a/R/bayesian/nodesplit/nodesplit_panel.R
+++ b/R/bayesian/nodesplit/nodesplit_panel.R
@@ -76,7 +76,6 @@ nodesplit_panel_server <- function(
       
       model_valid(
         parameter_matcher$Matches(
-          data = data(),
           treatment_df = treatment_df(),
           metaoutcome = metaoutcome(),
           outcome_measure = outcome_measure(),
@@ -85,10 +84,14 @@ nodesplit_panel_server <- function(
       )
     })
     
+    # Clear validity when data changes
+    observe({
+      model_valid(NULL)
+    }) |> bindEvent(data())
+    
     # Record inputs when model run
     observe({
       parameter_matcher$SetParameters(
-        data = data(),
         treatment_df = treatment_df(),
         metaoutcome = metaoutcome(),
         outcome_measure = outcome_measure(),

--- a/R/bayesian/nodesplit/nodesplit_panel.R
+++ b/R/bayesian/nodesplit/nodesplit_panel.R
@@ -7,6 +7,7 @@
 nodesplit_panel_ui <- function(id, item_name) {
   ns <- NS(id)
   div(
+    invalid_model_panel_ui(id = ns("model_invalid")),
     actionButton(inputId = ns("node"), label = glue::glue("Click here to run the nodesplitting analysis for {item_name}")),
     uiOutput(outputId = ns("node_plot_placeholder")),
     radioButtons(
@@ -93,6 +94,8 @@ nodesplit_panel_server <- function(
         shinyjs::disable(id = "downloadnode")
       }
     })
+    
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
     
     # number of comparisons
     ncomp <- reactive({

--- a/R/bayesian/nodesplit/nodesplit_panel.R
+++ b/R/bayesian/nodesplit/nodesplit_panel.R
@@ -43,6 +43,8 @@ nodesplit_panel_server <- function(
     model_nodesplit <- eventReactive(
       input$node,
       {
+        # Run nodesplit model, returning NULL if an error occurs.
+        # Errors will occur if there are no closed loops in the network.
         nodesplit_model <- tryCatch(
           expr = {
             nodesplit(
@@ -61,9 +63,11 @@ nodesplit_panel_server <- function(
       }
     )
     
+    # ReactiveVal contains validity state of the model. NULL if the model has not yet been run.
     model_valid = reactiveVal(NULL)
     parameter_matcher <- ParameterMatcher$new()
     
+    # Set validity when model input change
     observe({
       # Only assess the validity once the model has been run the first time
       if (is.null(model_valid())) {
@@ -81,6 +85,7 @@ nodesplit_panel_server <- function(
       )
     })
     
+    # Record inputs when model run
     observe({
       parameter_matcher$SetParameters(
         data = data(),

--- a/R/bayesian/nodesplit/nodesplit_panel.R
+++ b/R/bayesian/nodesplit/nodesplit_panel.R
@@ -61,10 +61,15 @@ nodesplit_panel_server <- function(
       }
     )
     
-    model_valid = reactiveVal(FALSE)
+    model_valid = reactiveVal(NULL)
     parameter_matcher <- ParameterMatcher$new()
     
     observe({
+      # Only assess the validity once the model has been run the first time
+      if (is.null(model_valid())) {
+        return()
+      }
+      
       model_valid(
         parameter_matcher$Matches(
           data = data(),
@@ -88,10 +93,10 @@ nodesplit_panel_server <- function(
     }) |> bindEvent(model_nodesplit())
     
     observe({
-      if (model_valid()) {
-        shinyjs::enable(id = "downloadnode")
-      } else {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id = "downloadnode")
+      } else {
+        shinyjs::enable(id = "downloadnode")
       }
     })
     
@@ -123,7 +128,7 @@ nodesplit_panel_server <- function(
     })
     
     output$node_plot<- renderPlot({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       req(input$node)

--- a/R/bayesian/ranking/ranking_forest_panel.R
+++ b/R/bayesian/ranking/ranking_forest_panel.R
@@ -41,14 +41,26 @@ ranking_forest_panel_server <- function(
     treat_order,
     frequentist_react,
     bugsnetdt_react,
+    model_valid,
     filename_prefix,
     title_prefix
     ) {
   moduleServer(id, function(input, output, session) {
+    
+    observe({
+      if (!model_valid()) {
+        shinyjs::disable(id = "download_rank_forest")
+      } else {
+        shinyjs::enable(id = "download_rank_forest")
+      }
+    })
 
     # Forest plots for ranking panel (different style due to using 'boxes' in UI) CRN
     # All studies #
     output$gemtc2 <- renderPlot({
+      if (!model_valid()) {
+        return()
+      }
       temp_dir <- tempdir()
       png(file.path(temp_dir, "forest.png"))  # initialise image
       gemtc::forest(model()$mtcRelEffects, digits = 3)
@@ -84,6 +96,9 @@ ranking_forest_panel_server <- function(
 
     # Text underneath
     output$relative_rank_text <- renderText({
+      if (!model_valid()) {
+        return()
+      }
       relative_rank_text(model())
     })
   })
@@ -106,14 +121,26 @@ ranking_forest_panel_baseline_risk_server <- function(
     model,
     treat_order,
     bugsnetdt_react,
+    model_valid,
     filename_prefix,
     title_prefix
 ) {
   moduleServer(id, function(input, output, session) {
     
+    observe({
+      if (!model_valid()) {
+        shinyjs::disable(id = "download_rank_forest")
+      } else {
+        shinyjs::enable(id = "download_rank_forest")
+      }
+    })
+    
     # Forest plots for ranking panel (different style due to using 'boxes' in UI) CRN
     # All studies #
     output$gemtc2 <- renderPlot({
+      if (!model_valid()) {
+        return()
+      }
       temp_dir <- tempdir()
       png(file.path(temp_dir, "forest.png"))  # initialise image
       bnma::network.forest.plot(model(), only.reference.treatment = TRUE)

--- a/R/bayesian/ranking/ranking_forest_panel.R
+++ b/R/bayesian/ranking/ranking_forest_panel.R
@@ -33,6 +33,7 @@ ranking_forest_panel_ui <- function(id) {
 #' @param treat_order Reactive containing treatments ordered by SUCRA
 #' @param frequentist_react Reactive containing frequentist meta-analysis
 #' @param bugsnetdt_react Reactive containing bugsnet meta-analysis
+#' @param model_valid Reactive containing whether the model is valid.
 #' @param filename_prefix Prefix to add before file names.
 #' @param title_prefix Prefix to add before plot titles.
 ranking_forest_panel_server <- function(
@@ -114,6 +115,7 @@ ranking_forest_panel_server <- function(
 #' @param model Reactive containing bayesian meta-analysis for all studies
 #' @param treat_order Reactive containing treatments ordered by SUCRA
 #' @param bugsnetdt_react Reactive containing bugsnet meta-analysis
+#' @param model_valid Reactive containing whether the model is valid.
 #' @param filename_prefix Prefix to add before file names.
 #' @param title_prefix Prefix to add before plot titles.
 ranking_forest_panel_baseline_risk_server <- function(

--- a/R/bayesian/ranking/ranking_forest_panel.R
+++ b/R/bayesian/ranking/ranking_forest_panel.R
@@ -48,7 +48,7 @@ ranking_forest_panel_server <- function(
   moduleServer(id, function(input, output, session) {
     
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id = "download_rank_forest")
       } else {
         shinyjs::enable(id = "download_rank_forest")
@@ -58,7 +58,7 @@ ranking_forest_panel_server <- function(
     # Forest plots for ranking panel (different style due to using 'boxes' in UI) CRN
     # All studies #
     output$gemtc2 <- renderPlot({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       temp_dir <- tempdir()
@@ -96,7 +96,7 @@ ranking_forest_panel_server <- function(
 
     # Text underneath
     output$relative_rank_text <- renderText({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       relative_rank_text(model())
@@ -128,7 +128,7 @@ ranking_forest_panel_baseline_risk_server <- function(
   moduleServer(id, function(input, output, session) {
     
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id = "download_rank_forest")
       } else {
         shinyjs::enable(id = "download_rank_forest")
@@ -138,7 +138,7 @@ ranking_forest_panel_baseline_risk_server <- function(
     # Forest plots for ranking panel (different style due to using 'boxes' in UI) CRN
     # All studies #
     output$gemtc2 <- renderPlot({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       temp_dir <- tempdir()

--- a/R/bayesian/ranking/ranking_network_panel.R
+++ b/R/bayesian/ranking/ranking_network_panel.R
@@ -46,10 +46,11 @@ ranking_network_panel_ui <- function(id) {
 
 #' Module server for the ranking network panel.
 #' 
-#' @param id ID of the module
-#' @param treat_order Reactive containing treatments ordered by SUCRA
-#' @param frequentist_react Reactive containing frequentist meta-analysis
-#' @param bugsnetdt_react Reactive containing bugsnet meta-analysis
+#' @param id ID of the module.
+#' @param treat_order Reactive containing treatments ordered by SUCRA.
+#' @param frequentist_react Reactive containing frequentist meta-analysis.
+#' @param bugsnetdt_react Reactive containing bugsnet meta-analysis.
+#' @param model_valid Reactive containing whether the model is valid.
 #' @param filename_prefix Prefix to add before file names.
 #' @param title_prefix Prefix to add beofre plot titles.
 ranking_network_panel_server <- function(

--- a/R/bayesian/ranking/ranking_network_panel.R
+++ b/R/bayesian/ranking/ranking_network_panel.R
@@ -64,7 +64,7 @@ ranking_network_panel_server <- function(
   moduleServer(id, function(input, output, session) {
     
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id = "download_network_rank")
       } else {
         shinyjs::enable(id = "download_network_rank")
@@ -72,7 +72,7 @@ ranking_network_panel_server <- function(
     })
     
     output$netGraphStatic1_rank <- renderPlot({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       if (input$networkstyle_rank == 'networkp1') {

--- a/R/bayesian/ranking/ranking_network_panel.R
+++ b/R/bayesian/ranking/ranking_network_panel.R
@@ -57,12 +57,24 @@ ranking_network_panel_server <- function(
     treat_order,
     frequentist_react,
     bugsnetdt_react,
+    model_valid,
     filename_prefix,
     title_prefix
     ) {
   moduleServer(id, function(input, output, session) {
     
+    observe({
+      if (!model_valid()) {
+        shinyjs::disable(id = "download_network_rank")
+      } else {
+        shinyjs::enable(id = "download_network_rank")
+      }
+    })
+    
     output$netGraphStatic1_rank <- renderPlot({
+      if (!model_valid()) {
+        return()
+      }
       if (input$networkstyle_rank == 'networkp1') {
         # Number of trials on line
         make_netgraph_rank(frequentist_react(), treat_order())

--- a/R/bayesian/ranking/ranking_page.R
+++ b/R/bayesian/ranking/ranking_page.R
@@ -49,6 +49,8 @@ ranking_page_ui <- function(id) {
 #' @param freq_sub Reactive containing frequentist meta-analysis for the sensitivity analysis.
 #' @param bugsnetdt Reactive containing bugsnet meta-analysis.
 #' @param bugsnetdt_sub Reactive containing bugsnet meta-analysis for sensitivity analysis
+#' @param model_valid Reactive containing whether the full model is valid.
+#' @param model_sub_valid Reactive containing whether the sensitivity analysis model is valid.
 ranking_page_server <- function(
     id,
     model,

--- a/R/bayesian/ranking/ranking_page.R
+++ b/R/bayesian/ranking/ranking_page.R
@@ -64,7 +64,9 @@ ranking_page_server <- function(
     freq_all,
     freq_sub,
     bugsnetdt,
-    bugsnetdt_sub
+    bugsnetdt_sub,
+    model_valid,
+    model_sub_valid
     ) {
   
   moduleServer(id, function(input, output, session) {
@@ -77,6 +79,7 @@ ranking_page_server <- function(
       rank_option = rank_option,
       frequentist = freq_all,
       bugsnetdt = bugsnetdt,
+      model_valid = model_valid,
       filename_prefix = "all_studies_",
       title_prefix = "All Studies"
     )
@@ -90,6 +93,7 @@ ranking_page_server <- function(
       rank_option = rank_option,
       frequentist = freq_sub,
       bugsnetdt = bugsnetdt_sub,
+      model_valid = model_sub_valid,
       filename_prefix = "filtered_studies_",
       title_prefix = "Filtered Studies"
     )

--- a/R/bayesian/ranking/ranking_page.R
+++ b/R/bayesian/ranking/ranking_page.R
@@ -7,9 +7,6 @@ ranking_page_ui <- function(id) {
   ns <- NS(id)
   div(
     helpText(
-      "Please note: if you change the selections on the sidebar,
-      you will need to re-run the primary and/or sensitivity analysis from the 'Forest Plot' page.",
-      tags$br(),
       tags$strong("Please note it may take up to 5 minutes to load the results.", style = "color:#FF0000"),
       tags$br(),
       tags$strong(

--- a/R/bayesian/ranking/ranking_panel.R
+++ b/R/bayesian/ranking/ranking_panel.R
@@ -13,6 +13,7 @@ ranking_panel_ui <- function(id, title, table_label) {
     solidHeader = TRUE,
     width = 12,
     collapsible = TRUE,
+    invalid_model_panel_ui(id = ns("model_invalid")),
     splitLayout(
       cellWidths = c("30%", "40%", "30%"),
       cellArgs = list(style = "height: 780px; padding: 16px; border: 2px solid gold; white-space: normal"),
@@ -65,6 +66,8 @@ ranking_panel_server <- function(
     package = "gemtc"
     ) {
   moduleServer(id, function(input, output, session) {
+    
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
     
     ranking_data <- eventReactive(
       model_valid(),

--- a/R/bayesian/ranking/ranking_panel.R
+++ b/R/bayesian/ranking/ranking_panel.R
@@ -57,6 +57,7 @@ ranking_panel_server <- function(
     rank_option,
     frequentist,
     bugsnetdt,
+    model_valid,
     filename_prefix,
     title_prefix,
     cov_value = reactive({NA}),
@@ -66,8 +67,12 @@ ranking_panel_server <- function(
   moduleServer(id, function(input, output, session) {
     
     ranking_data <- eventReactive(
-      model(),
+      model_valid(),
       {
+        if (!model_valid()) {
+          return()
+        }
+        
         obtain_rank_data(
           data(),
           metaoutcome(),
@@ -83,15 +88,24 @@ ranking_panel_server <- function(
 
     # Network plots for ranking panel (Bayesian) (they have slightly different formatting to those on tab1) CRN
     treat_order <- reactive({
+      if (is.null(ranking_data())) {
+        return()
+      }
       ranking_data()$SUCRA[order(ranking_data()$SUCRA$SUCRA), 1]
     }) # obtain treatments ordered by SUCRA #
     
     frequentist_react <- eventReactive(model(), {
+      if (is.null(ranking_data())) {
+        return()
+      }
       # These two lines are needed in case someone jumped to Bayesian page without running frequentist section, but am aware this can cause frequentist analysis to run twice (CRN)
       frequentist()
     })
     
     bugsnetdt_react <- eventReactive(model(), {
+      if (is.null(ranking_data())) {
+        return()
+      }
       bugsnetdt()
     })
     
@@ -102,6 +116,7 @@ ranking_panel_server <- function(
         treat_order = treat_order,
         frequentist_react = frequentist_react,
         bugsnetdt_react = bugsnetdt_react,
+        model_valid = model_valid,
         filename_prefix = filename_prefix,
         title_prefix = title_prefix
       )
@@ -111,6 +126,7 @@ ranking_panel_server <- function(
         model = model,
         treat_order = treat_order,
         bugsnetdt_react = bugsnetdt_react,
+        model_valid = model_valid,
         filename_prefix = filename_prefix,
         title_prefix = title_prefix
       )
@@ -119,6 +135,9 @@ ranking_panel_server <- function(
     }
     
     regression_text <- reactive({
+      if (!model_valid()) {
+        return()
+      }
       if (!is.na(cov_value())) {
         return(model()$cov_value_sentence)
       } else {
@@ -129,6 +148,7 @@ ranking_panel_server <- function(
     rankogram_panel_server(
       id = "rankogram",
       ranking_data = ranking_data,
+      model_valid = model_valid,
       filename_prefix = filename_prefix,
       regression_text = regression_text
     )
@@ -138,6 +158,7 @@ ranking_panel_server <- function(
       treat_order = treat_order,
       frequentist_react = frequentist_react,
       bugsnetdt_react = bugsnetdt_react,
+      model_valid = model_valid,
       filename_prefix = filename_prefix,
       title_prefix = title_prefix
     )

--- a/R/bayesian/ranking/ranking_panel.R
+++ b/R/bayesian/ranking/ranking_panel.R
@@ -70,12 +70,8 @@ ranking_panel_server <- function(
     invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
     
     ranking_data <- eventReactive(
-      model_valid(),
+      model(),
       {
-        if (!model_valid()) {
-          return()
-        }
-        
         obtain_rank_data(
           data(),
           metaoutcome(),
@@ -91,24 +87,15 @@ ranking_panel_server <- function(
 
     # Network plots for ranking panel (Bayesian) (they have slightly different formatting to those on tab1) CRN
     treat_order <- reactive({
-      if (is.null(ranking_data())) {
-        return()
-      }
       ranking_data()$SUCRA[order(ranking_data()$SUCRA$SUCRA), 1]
     }) # obtain treatments ordered by SUCRA #
     
     frequentist_react <- eventReactive(model(), {
-      if (is.null(ranking_data())) {
-        return()
-      }
       # These two lines are needed in case someone jumped to Bayesian page without running frequentist section, but am aware this can cause frequentist analysis to run twice (CRN)
       frequentist()
     })
     
     bugsnetdt_react <- eventReactive(model(), {
-      if (is.null(ranking_data())) {
-        return()
-      }
       bugsnetdt()
     })
     
@@ -138,9 +125,6 @@ ranking_panel_server <- function(
     }
     
     regression_text <- reactive({
-      if (!model_valid()) {
-        return()
-      }
       if (!is.na(cov_value())) {
         return(model()$cov_value_sentence)
       } else {

--- a/R/bayesian/ranking/ranking_panel.R
+++ b/R/bayesian/ranking/ranking_panel.R
@@ -44,6 +44,7 @@ ranking_panel_ui <- function(id, title, table_label) {
 #' @param rank_option Reactive containing ranking option: "good" or "bad" depending on whether small values are desirable or not
 #' @param frequentist Reactive containing frequentist meta-analysis
 #' @param bugsnetdt Reactive containing bugsnet meta-analysis
+#' @param model_valid Reactive containing whether the model is valid.
 #' @param filename_prefix Text to prefix the filename of all the downloads
 #' @param title_prefix Text to prefix the title of plots
 #' @param cov_value Value of covariate for regression analysis

--- a/R/bayesian/ranking/rankogram_panel.R
+++ b/R/bayesian/ranking/rankogram_panel.R
@@ -112,9 +112,6 @@ rankogram_panel_server <- function(
 
     # All rank plots in one function for easier loading when switching options #
     Rankplots <- reactive({
-      if (!model_valid()) {
-        return()
-      }
       plots <- list()
       plots$Litmus <- LitmusRankOGram(CumData = ranking_data()$Cumulative, SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, colourblind = FALSE, regression_text = regression_text())
       plots$Radial <- RadialSUCRA(SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, BUGSnetData = ranking_data()$BUGSnetData, colourblind = FALSE, regression_text = regression_text())

--- a/R/bayesian/ranking/rankogram_panel.R
+++ b/R/bayesian/ranking/rankogram_panel.R
@@ -101,7 +101,7 @@ rankogram_panel_server <- function(
   moduleServer(id, function(input, output, session) {
     
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id = "download_rank_plot")
         shinyjs::disable(id = "download_rank_table")
       } else {
@@ -122,7 +122,7 @@ rankogram_panel_server <- function(
 
     # Litmus Rank-O-Gram
     output$Litmus <- renderPlot({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       if (!input$Colour_blind) {
@@ -134,7 +134,7 @@ rankogram_panel_server <- function(
 
     # Radial SUCRA
     output$Radial <- renderPlot({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       if (!input$Colour_blind) {
@@ -186,7 +186,7 @@ rankogram_panel_server <- function(
     # Table of Probabilities (need to include SUCRA and have it as a collapsable table)
     output$rank_probs <- renderTable(
       {
-        if (!model_valid()) {
+        if (is.null(model_valid()) || !model_valid()) {
           return()
         }
         rank_probs_table(ranking_data())

--- a/R/bayesian/ranking/rankogram_panel.R
+++ b/R/bayesian/ranking/rankogram_panel.R
@@ -89,8 +89,9 @@ rankogram_panel_ui <- function(id, table_label) {
 #' 
 #' @param id ID of the module.
 #' @param ranking_data Reactive containing ranking data.
+#' @param model_valid Reactive containing whether the model is valid.
 #' @param filename_prefix Prefix to add before file names.
-#' @param regression_text Regression annotation if needed
+#' @param regression_text Regression annotation if needed.
 rankogram_panel_server <- function(
     id,
     ranking_data,

--- a/R/bayesian/ranking/rankogram_panel.R
+++ b/R/bayesian/ranking/rankogram_panel.R
@@ -94,13 +94,27 @@ rankogram_panel_ui <- function(id, table_label) {
 rankogram_panel_server <- function(
     id,
     ranking_data,
+    model_valid,
     filename_prefix,
     regression_text
     ) {
   moduleServer(id, function(input, output, session) {
+    
+    observe({
+      if (!model_valid()) {
+        shinyjs::disable(id = "download_rank_plot")
+        shinyjs::disable(id = "download_rank_table")
+      } else {
+        shinyjs::enable(id = "download_rank_plot")
+        shinyjs::enable(id = "download_rank_table")
+      }
+    })
 
     # All rank plots in one function for easier loading when switching options #
     Rankplots <- reactive({
+      if (!model_valid()) {
+        return()
+      }
       plots <- list()
       plots$Litmus <- LitmusRankOGram(CumData = ranking_data()$Cumulative, SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, colourblind = FALSE, regression_text = regression_text())
       plots$Radial <- RadialSUCRA(SUCRAData = ranking_data()$SUCRA, ColourData = ranking_data()$Colour, BUGSnetData = ranking_data()$BUGSnetData, colourblind = FALSE, regression_text = regression_text())
@@ -111,6 +125,9 @@ rankogram_panel_server <- function(
 
     # Litmus Rank-O-Gram
     output$Litmus <- renderPlot({
+      if (!model_valid()) {
+        return()
+      }
       if (!input$Colour_blind) {
         Rankplots()$Litmus
       } else {
@@ -120,6 +137,9 @@ rankogram_panel_server <- function(
 
     # Radial SUCRA
     output$Radial <- renderPlot({
+      if (!model_valid()) {
+        return()
+      }
       if (!input$Colour_blind) {
         Rankplots()$Radial$Original
       } else {
@@ -129,6 +149,9 @@ rankogram_panel_server <- function(
     
     # Alternative SUCRA plots
     output$RadialAlt <- renderPlot({
+      if (!model_valid()) {
+        return()
+      }
       if (!input$Colour_blind) {
         Rankplots()$Radial$Alternative
       } else {
@@ -166,6 +189,9 @@ rankogram_panel_server <- function(
     # Table of Probabilities (need to include SUCRA and have it as a collapsable table)
     output$rank_probs <- renderTable(
       {
+        if (!model_valid()) {
+          return()
+        }
         rank_probs_table(ranking_data())
       },
       digits = 2,

--- a/R/bayesian/result_details/result_details_page.R
+++ b/R/bayesian/result_details/result_details_page.R
@@ -39,24 +39,24 @@ result_details_page_ui <- function(id, item_names) {
 
 #' Module server for the result details page.
 #' 
-#' @param id ID of the module
+#' @param id ID of the module.
 #' @param models Vector of reactives containing bayesian meta-analyses.
+#' @param models_valid Vector of reactives containing whether each model is valid.
 #' @param package "gemtc" (default) or "bnma".
-result_details_page_server <- function(id, models, package = "gemtc") {
+result_details_page_server <- function(id, models, models_valid, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
     # Create server for each model
-    index <- 0
     sapply(
-      models,
-      function(mod) {
+      1:length(models),
+      function(index) {
         serv <- result_details_panel_server(
-          id = as.character(index),
-          model = mod,
+          id = as.character(index - 1),
+          model = models[index][[1]],
+          model_valid = models_valid[index][[1]],
           package = package
         )
         # Update the index variable in the outer scope with <<-
         # This updates the variable defined above the `sapply` call instead of creating a new variable with the same name within this inner function
-        index <<- index + 1
         return(serv)
       }
     )

--- a/R/bayesian/result_details/result_details_page.R
+++ b/R/bayesian/result_details/result_details_page.R
@@ -55,8 +55,6 @@ result_details_page_server <- function(id, models, models_valid, package = "gemt
           model_valid = models_valid[index][[1]],
           package = package
         )
-        # Update the index variable in the outer scope with <<-
-        # This updates the variable defined above the `sapply` call instead of creating a new variable with the same name within this inner function
         return(serv)
       }
     )

--- a/R/bayesian/result_details/result_details_page.R
+++ b/R/bayesian/result_details/result_details_page.R
@@ -11,11 +11,6 @@ result_details_page_ui <- function(id, item_names) {
   index <- 0
   
   div(
-    helpText(
-      "Please note: if you change the selections on the sidebar,
-      you will need to re-run the analysis from the 'Forest Plot' page."
-    ),
-    
     # This is the way to get a dynamic number of columns rendered into the row
     do.call(
       fluidRow,

--- a/R/bayesian/result_details/result_details_page.R
+++ b/R/bayesian/result_details/result_details_page.R
@@ -51,8 +51,8 @@ result_details_page_server <- function(id, models, models_valid, package = "gemt
       function(index) {
         serv <- result_details_panel_server(
           id = as.character(index - 1),
-          model = models[index][[1]],
-          model_valid = models_valid[index][[1]],
+          model = models[[index]],
+          model_valid = models_valid[[index]],
           package = package
         )
         return(serv)

--- a/R/bayesian/result_details/result_details_panel.R
+++ b/R/bayesian/result_details/result_details_panel.R
@@ -7,6 +7,7 @@
 result_details_panel_ui <- function(id, item_name) {
   ns <- NS(id)
   div(
+    invalid_model_panel_ui(id = ns("model_invalid")),
     p(tags$strong(glue::glue("Results details for {item_name}"))),
     shinycssloaders::withSpinner(
       verbatimTextOutput(outputId = ns("gemtc_results")),
@@ -30,6 +31,8 @@ result_details_panel_ui <- function(id, item_name) {
 #' @param model_valid Reactive containing whether the model is valid.
 result_details_panel_server <- function(id, model, model_valid, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
+    
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
     
     # Results details
     output$gemtc_results <- renderPrint({

--- a/R/bayesian/result_details/result_details_panel.R
+++ b/R/bayesian/result_details/result_details_panel.R
@@ -27,11 +27,15 @@ result_details_panel_ui <- function(id, item_name) {
 #' @param id ID of the module
 #' @param model Reactive containing bayesian meta-analysis
 #' @param package "gemtc" (default) or "bnma".
-result_details_panel_server <- function(id, model, package = "gemtc") {
+#' @param model_valid Reactive containing whether the model is valid
+result_details_panel_server <- function(id, model, model_valid, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
     
     # Results details
     output$gemtc_results <- renderPrint ({
+      if (!model_valid()) {
+        return()
+      }
       if (package == "gemtc") {
         return(model()$sumresults)
       } else if (package == "bnma") {
@@ -82,15 +86,21 @@ result_details_panel_server <- function(id, model, package = "gemtc") {
     })
     
     # Gelman plots
-    output$gemtc_gelman <- renderPlot ({
-      if (package == "gemtc") {
-        return(gelman.plot(model()$mtcResults))
-      } else if (package == "bnma") {
-        par(mfrow = c(n_rows(), 2))
-        return(BnmaGelmanPlots(gelman_plots = gelman_plots(), parameters = parameters()))
+    output$gemtc_gelman <- renderPlot(
+      {
+        if (!model_valid()) {
+          return()
+        }
+        if (package == "gemtc") {
+          return(gelman.plot(model()$mtcResults))
+        } else if (package == "bnma") {
+          par(mfrow = c(n_rows(), 2))
+          return(BnmaGelmanPlots(gelman_plots = gelman_plots(), parameters = parameters()))
+        }
+      },
+      height = function() {
+        n_rows() * 300
       }
-    },
-    height = function(){n_rows() * 300}
     )
   })
 }

--- a/R/bayesian/result_details/result_details_panel.R
+++ b/R/bayesian/result_details/result_details_panel.R
@@ -24,15 +24,15 @@ result_details_panel_ui <- function(id, item_name) {
 
 #' Module server for the result details panel.
 #' 
-#' @param id ID of the module
-#' @param model Reactive containing bayesian meta-analysis
+#' @param id ID of the module.
+#' @param model Reactive containing bayesian meta-analysis.
 #' @param package "gemtc" (default) or "bnma".
-#' @param model_valid Reactive containing whether the model is valid
+#' @param model_valid Reactive containing whether the model is valid.
 result_details_panel_server <- function(id, model, model_valid, package = "gemtc") {
   moduleServer(id, function(input, output, session) {
     
     # Results details
-    output$gemtc_results <- renderPrint ({
+    output$gemtc_results <- renderPrint({
       if (!model_valid()) {
         return()
       }

--- a/R/bayesian/result_details/result_details_panel.R
+++ b/R/bayesian/result_details/result_details_panel.R
@@ -36,7 +36,7 @@ result_details_panel_server <- function(id, model, model_valid, package = "gemtc
     
     # Results details
     output$gemtc_results <- renderPrint({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       if (package == "gemtc") {
@@ -91,7 +91,7 @@ result_details_panel_server <- function(id, model, model_valid, package = "gemtc
     # Gelman plots
     output$gemtc_gelman <- renderPlot(
       {
-        if (!model_valid()) {
+        if (is.null(model_valid()) || !model_valid()) {
           return()
         }
         if (package == "gemtc") {

--- a/R/bayesian/treatment_comparison_page.R
+++ b/R/bayesian/treatment_comparison_page.R
@@ -53,7 +53,7 @@ bayesian_treatment_comparisons_page_server <- function(
     invalid_model_panel_server(id = "model_invalid_sub", model_valid = model_sub_valid)
     
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id="downloadbaye_comparison")
       } else {
         shinyjs::enable(id="downloadbaye_comparison")
@@ -61,7 +61,7 @@ bayesian_treatment_comparisons_page_server <- function(
     })
     
     observe({
-      if (!model_sub_valid()) {
+      if (is.null(model_sub_valid()) || !model_sub_valid()) {
         shinyjs::disable(id="downloadbaye_comparison_sub")
       } else {
         shinyjs::enable(id="downloadbaye_comparison_sub")
@@ -73,7 +73,7 @@ bayesian_treatment_comparisons_page_server <- function(
       rownames = TRUE,
       colnames = TRUE,
       {
-        if (!model_valid()) {
+        if (is.null(model_valid()) || !model_valid()) {
           return()
         }
         baye_comp(model(), outcome_measure())
@@ -85,7 +85,7 @@ bayesian_treatment_comparisons_page_server <- function(
       rownames = TRUE,
       colnames = TRUE,
       {
-        if (!model_sub_valid()) {
+        if (is.null(model_sub_valid()) || !model_sub_valid()) {
           return()
         }
         baye_comp(model_sub(), outcome_measure())

--- a/R/bayesian/treatment_comparison_page.R
+++ b/R/bayesian/treatment_comparison_page.R
@@ -16,11 +16,13 @@ bayesian_treatment_comparisons_page_ui <- function(id) {
       )
     ),
     br(),
+    invalid_model_panel_ui(id = ns("model_invalid")),
     p(tags$strong("Treatment effects for all studies: comparison of all treatment pairs.")),
     tableOutput(outputId = ns("baye_comparison")),
     downloadButton(outputId = ns('downloadbaye_comparison')),
     br(),
     br(),
+    invalid_model_panel_ui(id = ns("model_invalid_sub")),
     p(tags$strong("Treatment effects with selected studies excluded: comparison of all treatment pairs.")),
     tableOutput(outputId = ns("baye_comparison_sub")),
     downloadButton(outputId = ns('downloadbaye_comparison_sub'))
@@ -46,6 +48,9 @@ bayesian_treatment_comparisons_page_server <- function(
     ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+    
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
+    invalid_model_panel_server(id = "model_invalid_sub", model_valid = model_sub_valid)
     
     observe({
       if (!model_valid()) {

--- a/R/bayesian/treatment_comparison_page.R
+++ b/R/bayesian/treatment_comparison_page.R
@@ -49,11 +49,17 @@ bayesian_treatment_comparisons_page_server <- function(
     
     observe({
       if (!model_valid()) {
-        shinyjs::disable(id="downloadbaye_comparison_sub")
         shinyjs::disable(id="downloadbaye_comparison")
       } else {
-        shinyjs::enable(id="downloadbaye_comparison_sub")
         shinyjs::enable(id="downloadbaye_comparison")
+      }
+    })
+    
+    observe({
+      if (!model_sub_valid()) {
+        shinyjs::disable(id="downloadbaye_comparison_sub")
+      } else {
+        shinyjs::enable(id="downloadbaye_comparison_sub")
       }
     })
 
@@ -74,7 +80,7 @@ bayesian_treatment_comparisons_page_server <- function(
       rownames = TRUE,
       colnames = TRUE,
       {
-        if (!model_valid()) {
+        if (!model_sub_valid()) {
           return()
         }
         baye_comp(model_sub(), outcome_measure())

--- a/R/bayesian/treatment_comparison_page.R
+++ b/R/bayesian/treatment_comparison_page.R
@@ -34,25 +34,51 @@ bayesian_treatment_comparisons_page_ui <- function(id) {
 #' @param model Reactive containing bayesian meta-analysis for all studies
 #' @param model_sub Reactive containing meta-analysis with studies excluded
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD", "SMD", "OR, "RR", or "RD"
+#' @param model_valid Reactive containing whether the model is valid
+#' @param model_sub_valid Reactive containing whether the sensitivity analysis model is valid
 bayesian_treatment_comparisons_page_server <- function(
     id,
     model,
     model_sub,
-    outcome_measure
+    outcome_measure,
+    model_valid = reactiveVal(TRUE),
+    model_sub_valid = reactiveVal(TRUE)
     ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+    
+    observe({
+      if (!model_valid()) {
+        shinyjs::disable(id="downloadbaye_comparison_sub")
+        shinyjs::disable(id="downloadbaye_comparison")
+      } else {
+        shinyjs::enable(id="downloadbaye_comparison_sub")
+        shinyjs::enable(id="downloadbaye_comparison")
+      }
+    })
 
     # Treatment effects for all studies
-    output$baye_comparison <- renderTable ({
-      baye_comp(model(), outcome_measure())
-    }, rownames=TRUE, colnames = TRUE
+    output$baye_comparison <- renderTable(
+      rownames = TRUE,
+      colnames = TRUE,
+      {
+        if (!model_valid()) {
+          return()
+        }
+        baye_comp(model(), outcome_measure())
+      }
     )
 
     # Treatment effects with studies excluded
-    output$baye_comparison_sub <- renderTable ({
-      baye_comp(model_sub(), outcome_measure())
-    }, rownames=TRUE, colnames = TRUE
+    output$baye_comparison_sub <- renderTable (
+      rownames = TRUE,
+      colnames = TRUE,
+      {
+        if (!model_valid()) {
+          return()
+        }
+        baye_comp(model_sub(), outcome_measure())
+      }
     )
 
     output$downloadbaye_comparison <- downloadHandler(

--- a/R/bayesian/treatment_comparison_page.R
+++ b/R/bayesian/treatment_comparison_page.R
@@ -6,7 +6,6 @@
 bayesian_treatment_comparisons_page_ui <- function(id) {
   ns <- NS(id)
   div(
-    helpText("Please note: if you change the selections on the sidebar, you will need to re-run the primary and/or sensitivity analysis from the 'Forest Plot' page."),
     p(
       tags$strong(
         "In contrast to the 'comparison of all treatment pairs' tab in the frequentist NMA results,

--- a/R/data_analysis_page.R
+++ b/R/data_analysis_page.R
@@ -195,8 +195,6 @@ data_analysis_page_server <- function(id, data, is_default_data, treatment_df, m
       freq_sub = freq_sub
     )
 
-
-
     ######################
     ### 2. Frequentist ###
     ######################
@@ -214,7 +212,6 @@ data_analysis_page_server <- function(id, data, is_default_data, treatment_df, m
       treatment_df = treatment_df,
       reference_alter = reference_alter
     )
-
 
     #####################
     #### 3. Bayesian ####
@@ -242,6 +239,7 @@ data_analysis_page_server <- function(id, data, is_default_data, treatment_df, m
     ############################
     #### 4. Meta-regression ####
     ############################
+    
     meta_regression_tab_server(
       id = "meta_regression",
       all_data = data,

--- a/R/data_summary_panel.R
+++ b/R/data_summary_panel.R
@@ -2,6 +2,7 @@
 #' Module UI for the data summary panel.
 #' 
 #' @param id ID of the module
+#' @param page_numbering PageNumbering object for giving each page a unique identifier in the UI
 #' @return Div for the panel
 data_summary_panel_ui <- function(id, page_numbering) {
   ns <- NS(id)

--- a/R/frequentist_analysis_panel.R
+++ b/R/frequentist_analysis_panel.R
@@ -2,6 +2,7 @@
 #' Module UI for the frquentist analysis panel.
 #' 
 #' @param id ID of the module
+#' @param page_numbering PageNumbering object for giving each page a unique identifier in the UI
 #' @return Div for the panel
 frequentist_analysis_panel_ui <- function(id, page_numbering) {
   ns <- NS(id)

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -235,7 +235,7 @@ baseline_risk_analysis_panel_server <- function(    id,
     deviance_report_page_server(id = "baseline_risk_deviance_report", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
     
     # 4c-8 Model details
-    model_details_panel_server(id = "baseline_risk_model_details", models = c(model_reactive), package = "bnma")
+    model_details_panel_server(id = "baseline_risk_model_details", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
     
     })
 }

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -229,7 +229,7 @@ baseline_risk_analysis_panel_server <- function(    id,
     covariate_nodesplit_page_server(id = "baseline_risk_nodesplit")
     
     # 4b-6 Result details
-    result_details_page_server(id = "baseline_risk_result_details", models = c(model_reactive), package = "bnma")
+    result_details_page_server(id = "baseline_risk_result_details", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
     
     # 4b-7 Deviance report
     deviance_report_page_server(id = "baseline_risk_deviance_report", models = c(model_reactive), package = "bnma")

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -152,9 +152,11 @@ baseline_risk_analysis_panel_server <- function(    id,
              )
     })
     
+    # ReactiveVal contains validity state of the model. NULL if the model has not yet been run.
     model_valid = reactiveVal(NULL)
     parameter_matcher <- ParameterMatcher$new()
     
+    # Set validity when model input change
     observe({
       # Only assess the validity once the model has been run the first time
       if (is.null(model_valid())) {
@@ -172,6 +174,7 @@ baseline_risk_analysis_panel_server <- function(    id,
       )
     })
     
+    # Record inputs when model run
     observe({
       parameter_matcher$SetParameters(
         all_data=all_data(),

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -232,7 +232,7 @@ baseline_risk_analysis_panel_server <- function(    id,
     result_details_page_server(id = "baseline_risk_result_details", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
     
     # 4b-7 Deviance report
-    deviance_report_page_server(id = "baseline_risk_deviance_report", models = c(model_reactive), package = "bnma")
+    deviance_report_page_server(id = "baseline_risk_deviance_report", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
     
     # 4c-8 Model details
     model_details_panel_server(id = "baseline_risk_model_details", models = c(model_reactive), package = "bnma")

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -207,7 +207,8 @@ baseline_risk_analysis_panel_server <- function(    id,
     treatment_comparisons_page_baseline_risk_server(
       id = "baseline_risk_treatment_comparisons",
       model = model_reactive,
-      outcome_measure = outcome_measure
+      outcome_measure = outcome_measure,
+      model_valid = model_valid
     )
     
     # 4b-4 Ranking Panel

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -152,10 +152,15 @@ baseline_risk_analysis_panel_server <- function(    id,
              )
     })
     
-    model_valid = reactiveVal(FALSE)
+    model_valid = reactiveVal(NULL)
     parameter_matcher <- ParameterMatcher$new()
     
     observe({
+      # Only assess the validity once the model has been run the first time
+      if (is.null(model_valid())) {
+        return()
+      }
+      
       model_valid(
         parameter_matcher$Matches(
           all_data=all_data(),

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -162,7 +162,6 @@ baseline_risk_analysis_panel_server <- function(    id,
           metaoutcome=metaoutcome(),
           outcome_measure=outcome_measure(),
           model_effects=model_effects(),
-          rank_option=rank_option(),
           regressor_type=model_reactives$regressor_type()
         )
       )
@@ -174,7 +173,6 @@ baseline_risk_analysis_panel_server <- function(    id,
         metaoutcome=metaoutcome(),
         outcome_measure=outcome_measure(),
         model_effects=model_effects(),
-        rank_option=rank_option(),
         regressor_type=model_reactives$regressor_type()
       )
       model_valid(TRUE)
@@ -201,7 +199,8 @@ baseline_risk_analysis_panel_server <- function(    id,
       model_reactive = model_reactive,
       metaoutcome = metaoutcome,
       outcome_measure = outcome_measure,
-      bugsnetdt = bugsnetdt
+      bugsnetdt = bugsnetdt,
+      model_valid = model_valid
     )
     
     # 4b-3 Treatment comparisons

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -1,6 +1,7 @@
 #' Create the baseline risk analysis panel.
 #'
 #' @param id ID of the module
+#' @param page_numbering PageNumbering object for giving each page a unique identifier in the UI
 #' @return Div containing the module UI
 baseline_risk_analysis_panel_ui <- function(id, page_numbering) {
   ns <- NS(id)

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -218,10 +218,12 @@ baseline_risk_analysis_panel_server <- function(    id,
       data = long_data,
       treatment_df = treatment_df,
       metaoutcome = metaoutcome,
+      outcome_measure = outcome_measure,
       model_effects = model_effects,
       rank_option = rank_option,
       freq_all = freq_all,
       bugsnetdt = bugsnetdt,
+      model_valid = model_valid,
       package = "bnma"
     )
       
@@ -237,6 +239,6 @@ baseline_risk_analysis_panel_server <- function(    id,
     # 4c-8 Model details
     model_details_panel_server(id = "baseline_risk_model_details", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
     
-    })
+  })
 }
 

--- a/R/meta_regression/cov_ranking_page.R
+++ b/R/meta_regression/cov_ranking_page.R
@@ -7,9 +7,6 @@ covariate_ranking_page_ui <- function(id) {
   ns <- NS(id)
   div(
     helpText(
-      "Please note: if you change the selections on the sidebar,
-      you will need to re-run the primary and/or sensitivity analysis from the 'Forest Plot' page.",
-      tags$br(),
       tags$strong("Please note it may take up to 5 minutes to load the results.", style = "color:#FF0000"),
       tags$br(),
       tags$strong(

--- a/R/meta_regression/cov_ranking_page.R
+++ b/R/meta_regression/cov_ranking_page.R
@@ -41,6 +41,7 @@ covariate_ranking_page_ui <- function(id) {
 #' @param rank_option Reactive containing ranking option: "good" or "bad" depending on whether small values are desirable or not.
 #' @param freq_all Reactive containing frequentist meta-analysis.
 #' @param bugsnetdt Reactive containing bugsnet meta-analysis.
+#' @param model_valid Reactive containing whether the model is valid.
 #' @param cov_value Value of covariate for regression analysis.
 #' @param package "gemtc" or "bnma". Defaults to "gemtc".
 #' regression_text Annotation text for regression model plots.

--- a/R/meta_regression/cov_ranking_page.R
+++ b/R/meta_regression/cov_ranking_page.R
@@ -55,7 +55,8 @@ covariate_ranking_page_server <- function(
     rank_option,
     freq_all,
     bugsnetdt,
-    cov_value,
+    model_valid,
+    cov_value = reactive({NA}),
     package = "gemtc"
     ) {
   
@@ -71,6 +72,7 @@ covariate_ranking_page_server <- function(
         rank_option = rank_option,
         frequentist = freq_all,
         bugsnetdt = bugsnetdt,
+        model_valid = model_valid,
         filename_prefix = "regression_",
         title_prefix = "Regression analysis",
         cov_value = cov_value
@@ -85,8 +87,10 @@ covariate_ranking_page_server <- function(
         rank_option = rank_option,
         frequentist = freq_all,
         bugsnetdt = bugsnetdt,
+        model_valid = model_valid,
         filename_prefix = "baseline_risk_",
         title_prefix = "Baseline risk",
+        cov_value = cov_value,
         package = package
       )
     } else{

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -286,6 +286,7 @@ covariate_analysis_panel_server <- function(
       rank_option = rank_option,
       freq_all = freq_all,
       bugsnetdt = bugsnetdt,
+      model_valid = model_valid,
       cov_value = covariate_value
     )
     # 4c-5 Nodesplit model

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -295,7 +295,7 @@ covariate_analysis_panel_server <- function(
     result_details_page_server(id = "result_details", models = c(model_output), models_valid = c(model_valid))
     
     # 4c-7 Deviance report
-    deviance_report_page_server(id = "deviance_report", models = c(model_output))
+    deviance_report_page_server(id = "deviance_report", models = c(model_output), models_valid = c(model_valid))
     
     # 4c-8 Model details
     model_details_panel_server(id = "model_details", models = c(model_output))

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -292,7 +292,7 @@ covariate_analysis_panel_server <- function(
     covariate_nodesplit_page_server(id = "nodesplit")
     
     # 4c-6 Result details
-    result_details_page_server(id = "result_details", models = c(model_output))
+    result_details_page_server(id = "result_details", models = c(model_output), models_valid = c(model_valid))
     
     # 4c-7 Deviance report
     deviance_report_page_server(id = "deviance_report", models = c(model_output))

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -213,10 +213,15 @@ covariate_analysis_panel_server <- function(
       )
     })
     
-    model_valid = reactiveVal(FALSE)
+    model_valid = reactiveVal(NULL)
     parameter_matcher <- ParameterMatcher$new()
     
     observe({
+      # Only assess the validity once the model has been run the first time
+      if (is.null(model_valid())) {
+        return()
+      }
+      
       model_valid(
         parameter_matcher$Matches(
           all_data=all_data(),

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -270,7 +270,8 @@ covariate_analysis_panel_server <- function(
     covariate_treatment_comparisons_page_server(
       id = "cov_treatment_comparisons",
       model = model_output,
-      outcome_measure = outcome_measure
+      outcome_measure = outcome_measure,
+      model_valid = model_valid
     )
     
     # 4c-4 Ranking Panel

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -213,9 +213,11 @@ covariate_analysis_panel_server <- function(
       )
     })
     
+    # ReactiveVal contains validity state of the model. NULL if the model has not yet been run.
     model_valid = reactiveVal(NULL)
     parameter_matcher <- ParameterMatcher$new()
     
+    # Set validity when model input change
     observe({
       # Only assess the validity once the model has been run the first time
       if (is.null(model_valid())) {
@@ -234,6 +236,7 @@ covariate_analysis_panel_server <- function(
       )
     })
     
+    # Record inputs when model run
     observe({
       parameter_matcher$SetParameters(
         all_data=all_data(),

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -1,6 +1,7 @@
 #' Create the covariate analysis panel.
 #'
 #' @param id ID of the module
+#' @param page_numbering PageNumbering object for giving each page a unique identifier in the UI
 #' @return Div containing the module UI
 covariate_analysis_panel_ui <- function(id, page_numbering) {
   ns <- NS(id)

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -227,7 +227,6 @@ covariate_analysis_panel_server <- function(
       
       model_valid(
         parameter_matcher$Matches(
-          all_data=all_data(),
           metaoutcome=metaoutcome(),
           outcome_measure=outcome_measure(),
           model_effects=model_effects(),
@@ -237,10 +236,14 @@ covariate_analysis_panel_server <- function(
       )
     })
     
+    # Clear validity when data changes
+    observe({
+      model_valid(NULL)
+    }) |> bindEvent(all_data())
+    
     # Record inputs when model run
     observe({
       parameter_matcher$SetParameters(
-        all_data=all_data(),
         metaoutcome=metaoutcome(),
         outcome_measure=outcome_measure(),
         model_effects=model_effects(),

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -298,7 +298,7 @@ covariate_analysis_panel_server <- function(
     deviance_report_page_server(id = "deviance_report", models = c(model_output), models_valid = c(model_valid))
     
     # 4c-8 Model details
-    model_details_panel_server(id = "model_details", models = c(model_output))
+    model_details_panel_server(id = "model_details", models = c(model_output), models_valid = c(model_valid))
     
   })
 }

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -223,7 +223,6 @@ covariate_analysis_panel_server <- function(
           metaoutcome=metaoutcome(),
           outcome_measure=outcome_measure(),
           model_effects=model_effects(),
-          rank_option=rank_option(),
           regressor_type=model_reactives$regressor_type(),
           covariate_type=covariate_type()
         )
@@ -236,7 +235,6 @@ covariate_analysis_panel_server <- function(
         metaoutcome=metaoutcome(),
         outcome_measure=outcome_measure(),
         model_effects=model_effects(),
-        rank_option=rank_option(),
         regressor_type=model_reactives$regressor_type(),
         covariate_type=covariate_type()
       )
@@ -264,7 +262,8 @@ covariate_analysis_panel_server <- function(
       analysis_type = "Regression",
       metaoutcome = metaoutcome,
       outcome_measure = outcome_measure,
-      bugsnetdt = bugsnetdt
+      bugsnetdt = bugsnetdt,
+      model_valid = model_valid
     )
     
     # 4c-3 Treatment comparisons

--- a/R/meta_regression/meta_regression_tab.R
+++ b/R/meta_regression/meta_regression_tab.R
@@ -162,7 +162,6 @@ meta_regression_tab_server <- function(
             )
           }
         )
-        
       }
     )
   })

--- a/R/meta_regression/meta_regression_tab.R
+++ b/R/meta_regression/meta_regression_tab.R
@@ -1,6 +1,7 @@
 #' Create the meta-regression panel.
 #'
 #' @param id ID of the module
+#' @param page_numbering PageNumbering object for giving each page a unique identifier in the UI
 #' @return Div containing the module
 meta_regression_tab_ui <- function(id, page_numbering) {
   ns <- NS(id)

--- a/R/meta_regression/treatment_comparison_page.R
+++ b/R/meta_regression/treatment_comparison_page.R
@@ -40,7 +40,7 @@ covariate_treatment_comparisons_page_server <- function(
     id,
     model,
     outcome_measure,
-    model_valid = reactiveVal(TRUE)
+    model_valid
     ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns

--- a/R/meta_regression/treatment_comparison_page.R
+++ b/R/meta_regression/treatment_comparison_page.R
@@ -34,24 +34,43 @@ covariate_treatment_comparisons_page_ui <- function(id) {
 #' @param id ID of the module
 #' @param model Reactive containing covariate regression meta-analysis for all studies
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD", "SMD", "OR, "RR", or "RD"
+#' @param model_valid Reactive containing whether the model is valid
 covariate_treatment_comparisons_page_server <- function(
     id,
     model,
-    outcome_measure
+    outcome_measure,
+    model_valid = reactiveVal(TRUE)
     ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+    
+    observe({
+      if (!model_valid()) {
+        shinyjs::disable(id="downloadbaye_comparison")
+      } else {
+        shinyjs::enable(id="downloadbaye_comparison")
+      }
+    })
 
     # Treatment effects for all studies
-    output$baye_comparison <- renderTable ({
-      baye_comp(model(), outcome_measure())
-    }, rownames=TRUE, colnames = TRUE
+    output$baye_comparison <- renderTable(
+      rownames = TRUE,
+      colnames = TRUE,
+      {
+        if (!model_valid()) {
+          return()
+        }
+        baye_comp(model(), outcome_measure())
+      }
     )
     
     output$package <- reactive({"gemtc"})
     outputOptions(x = output, name = "package", suspendWhenHidden = FALSE)
     
     output$cov_value_statement <- renderText({
+      if (!model_valid()) {
+        return()
+      }
       model()$cov_value_sentence
     })
 
@@ -74,20 +93,32 @@ covariate_treatment_comparisons_page_server <- function(
 #' @param id ID of the module
 #' @param model Reactive containing covariate regression meta-analysis for all studies
 #' @param outcome_measure Reactive containing meta analysis outcome measure: "MD" or "OR"
+#' @param model_valid Reactive containing whether the model is valid
 treatment_comparisons_page_baseline_risk_server <- function(
     id,
     model,
-    outcome_measure
+    outcome_measure,
+    model_valid = reactiveVal(TRUE)
 ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
+    observe({
+      if (!model_valid()) {
+        shinyjs::disable(id="downloadbaye_comparison")
+      } else {
+        shinyjs::enable(id="downloadbaye_comparison")
+      }
+    })
+    
     # Treatment effects for all studies
     output$baye_comparison <- renderTable(
       {
+        if (!model_valid()) {
+          return()
+        }
         BaselineRiskRelativeEffectsTable(
-          bnma::relative.effects.table(model(),
-                                       summary_stat = "ci")
+          bnma::relative.effects.table(model(), summary_stat = "ci")
         )
       },
       rownames = TRUE,

--- a/R/meta_regression/treatment_comparison_page.R
+++ b/R/meta_regression/treatment_comparison_page.R
@@ -18,6 +18,7 @@ covariate_treatment_comparisons_page_ui <- function(id) {
       )
     ),
     br(),
+    invalid_model_panel_ui(id = ns("model_invalid")),
     p(tags$strong("Treatment effects for all studies: comparison of all treatment pairs.")),
     tableOutput(outputId = ns("baye_comparison")),
     conditionalPanel(condition = "output.package == 'gemtc'",
@@ -44,8 +45,10 @@ covariate_treatment_comparisons_page_server <- function(
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
+    
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id="downloadbaye_comparison")
       } else {
         shinyjs::enable(id="downloadbaye_comparison")
@@ -57,7 +60,7 @@ covariate_treatment_comparisons_page_server <- function(
       rownames = TRUE,
       colnames = TRUE,
       {
-        if (!model_valid()) {
+        if (is.null(model_valid()) || !model_valid()) {
           return()
         }
         baye_comp(model(), outcome_measure())
@@ -68,7 +71,7 @@ covariate_treatment_comparisons_page_server <- function(
     outputOptions(x = output, name = "package", suspendWhenHidden = FALSE)
     
     output$cov_value_statement <- renderText({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         return()
       }
       model()$cov_value_sentence
@@ -103,8 +106,10 @@ treatment_comparisons_page_baseline_risk_server <- function(
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
+    
     observe({
-      if (!model_valid()) {
+      if (is.null(model_valid()) || !model_valid()) {
         shinyjs::disable(id="downloadbaye_comparison")
       } else {
         shinyjs::enable(id="downloadbaye_comparison")
@@ -114,7 +119,7 @@ treatment_comparisons_page_baseline_risk_server <- function(
     # Treatment effects for all studies
     output$baye_comparison <- renderTable(
       {
-        if (!model_valid()) {
+        if (is.null(model_valid()) || !model_valid()) {
           return()
         }
         BaselineRiskRelativeEffectsTable(

--- a/R/meta_regression/treatment_comparison_page.R
+++ b/R/meta_regression/treatment_comparison_page.R
@@ -6,18 +6,18 @@
 covariate_treatment_comparisons_page_ui <- function(id) {
   ns <- NS(id)
   div(
-    helpText("Please note: if you change the selections on the sidebar, you will need to re-run the analysis from the 'Forest Plot' page."),
-    p(
+    conditionalPanel(
+      condition = "output.package == 'gemtc'",
+      ns = ns,
       tags$strong(
-        conditionalPanel(condition = "output.package == 'gemtc'",
-                         ns = ns,
-                         p("This table only contains the estimates from the network meta analysis,
-        i.e. does not contain estimates from pairwise meta-analysis which only contains direct evidence.
-        If you would like to obtain the pairwise meta-analysis results, please run 4c-4. Nodesplit model")
+        p(
+          "This table only contains the estimates from the network meta analysis,
+          i.e. does not contain estimates from pairwise meta-analysis which only contains direct evidence.
+          If you would like to obtain the pairwise meta-analysis results, please run 4c-4. Nodesplit model"
         )
-      )
+      ),
+      br()
     ),
-    br(),
     invalid_model_panel_ui(id = ns("model_invalid")),
     p(tags$strong("Treatment effects for all studies: comparison of all treatment pairs.")),
     tableOutput(outputId = ns("baye_comparison")),


### PR DESCRIPTION
Everything is cleared when the model becomes invalid, and re-rendered when the model becomes valid.

This is somewhat intensive, but hiding the contents of `withSpinner()` results in infinite spinners, which is very misleading. I think that this is reasonable for now. The biggest problem is with the deviance report running a full UME model every time it renders. This is a bigger issue than this task, so I've raised it as issue #215 .