### PR TITLE
Mi 95 add trace and density plots

### DIFF
--- a/R/bayesian/bayesian_analysis_panel.R
+++ b/R/bayesian/bayesian_analysis_panel.R
@@ -32,8 +32,8 @@ bayesian_analysis_panel_ui <- function(id, page_numbering) {
         result_details_page_ui(id = ns("result_details"), item_names = c("all studies", "the sensitivity analysis"))
       ),
       tabPanel(
-        title = paste0(page_numbering$AddChild(), " Deviance report"),
-        deviance_report_page_ui(id = ns("deviance_report"), item_names = c("all studies", "the sensitivity analysis"))
+        title = paste0(page_numbering$AddChild(), " Diagnostics"),
+        diagnostics_page_ui(id = ns("diagnostics"), item_names = c("all studies", "the sensitivity analysis"), page_numbering)
       ),
       tabPanel(
         title = paste0(page_numbering$AddChild(), " Model details"),
@@ -172,8 +172,8 @@ bayesian_analysis_panel_server <- function(
     )
 
     # 3f. Deviance report
-    deviance_report_page_server(
-      id = "deviance_report",
+    diagnostics_page_server(
+      id = "diagnostics",
       models = c(model, model_sub),
       models_valid = c(model_valid, model_sub_valid)
     )

--- a/R/bayesian/deviance/diagnostics_page.R
+++ b/R/bayesian/deviance/diagnostics_page.R
@@ -1,0 +1,41 @@
+
+#' Module UI for the diagnostics page
+#' 
+#' @param id ID of the module
+#' @param item_names Vector of item names to be shown side-by-side in the page.
+#' @return Div for the panel
+diagnostics_page_ui <- function(id, item_names, page_numbering) {
+  ns <- NS(id)
+
+  page_numbering$DiveLevel()
+  
+  ui = tabsetPanel(
+    tabPanel(
+      title = paste0(page_numbering$AddChild(), " MCMC"),
+      mcmc_page_ui(id = ns("mcmc"), item_names = item_names)
+    ),
+    tabPanel(
+      title = paste0(page_numbering$AddChild(), " Deviance"),
+      deviance_report_page_ui(id = ns("deviance"), item_names = item_names)
+    )
+  )
+  
+  page_numbering$FloatLevel()
+  
+  return(ui)
+}
+
+
+#' Module server for the diagnostics page.
+#' 
+#' @param id ID of the module.
+#' @param models Vector of reactives containing bayesian meta-analyses.
+#' @param models_valid Vector of reactives containing whether each model is valid.
+#' @param package "gemtc" (default) or "bnma".
+diagnostics_page_server <- function(id, models, models_valid, package = "gemtc") {
+  moduleServer(id, function(input, output, session) {
+    mcmc_page_server(id = "mcmc", models = models, models_valid = models_valid, package = package)
+    deviance_report_page_server(id = "deviance", models = models, models_valid = models_valid, package = package)
+  })
+}
+

--- a/R/bayesian/deviance/mcmc_page.R
+++ b/R/bayesian/deviance/mcmc_page.R
@@ -1,0 +1,58 @@
+
+#' Module UI for the MCMC page
+#' 
+#' @param id ID of the module
+#' @param item_names Vector of item names to be shown side-by-side in the page.
+#' @return Div for the panel
+mcmc_page_ui <- function(id, item_names) {
+  ns <- NS(id)
+  
+  # Matrix containing plots for named items
+  index <- 0
+  
+  div(
+    # This is the way to get a dynamic number of columns rendered into the row
+    do.call(
+      fluidRow,
+      lapply(
+        item_names,
+        function(name) {
+          col <- column(
+            width = 12 / length(item_names),
+            mcmc_panel_ui(id = ns(as.character(index)), item_name = name)
+          )
+          # Update the index variable in the outer scope with <<-
+          # This updates the variable defined above the `div` call instead of creating a new variable with the same name within this inner function
+          index <<- index + 1
+          return(col)
+        }
+      )
+    )
+  )
+}
+
+
+#' Module server for the MCMC page.
+#' 
+#' @param id ID of the module.
+#' @param models Vector of reactives containing bayesian meta-analyses.
+#' @param models_valid Vector of reactives containing whether each model is valid.
+#' @param package "gemtc" (default) or "bnma".
+mcmc_page_server <- function(id, models, models_valid, package = "gemtc") {
+  moduleServer(id, function(input, output, session) {
+    # Create server for each model
+    sapply(
+      1:length(models),
+      function(index) {
+        serv <- mcmc_panel_server(
+          id = as.character(index - 1),
+          model = models[[index]],
+          model_valid = models_valid[[index]],
+          package = package
+        )
+        return(serv)
+      }
+    )
+  })
+}
+

--- a/R/bayesian/deviance/mcmc_panel.R
+++ b/R/bayesian/deviance/mcmc_panel.R
@@ -1,0 +1,159 @@
+
+#' Module UI for the MCMC panel
+#' 
+#' @param id ID of the module
+#' @param item_name Name of this deviance report item.
+#' @return Div for the panel
+mcmc_panel_ui <- function(id, item_name) {
+  ns <- NS(id)
+  div(
+    invalid_model_panel_ui(id = ns("model_invalid")),
+
+    p(tags$strong(glue::glue("Gelman convergence assessment plots for {item_name}"))),
+    shinycssloaders::withSpinner(
+      plotOutput(outputId = ns("gemtc_gelman"), inline = TRUE),
+      type = 6
+    ),
+    
+    p(tags$strong(glue::glue("Trace plots for {item_name}"))),
+    shinycssloaders::withSpinner(
+      plotOutput(outputId = ns("trace_plots"), inline = TRUE),
+      type = 6
+    ),
+    
+    p(tags$strong(glue::glue("Posterior density plots for {item_name}"))),
+    shinycssloaders::withSpinner(
+      plotOutput(outputId = ns("density_plots"), inline = TRUE),
+      type = 6
+    )
+  )
+}
+
+
+
+#' Module server for the MCMC panel.
+#' 
+#' @param id ID of the module.
+#' @param model Reactive containing bayesian meta-analysis.
+#' @param package "gemtc" (default) or "bnma".
+#' @param model_valid Reactive containing whether the model is valid.
+mcmc_panel_server <- function(id, model, model_valid, package = "gemtc") {
+  moduleServer(id, function(input, output, session) {
+    
+    invalid_model_panel_server(id = "model_invalid", model_valid = model_valid)
+    
+    #Need to use bnma terminology for covariate parameters below
+    cov_parameters <- reactive({
+      if (model()$network$baseline == "common"){
+        return("shared")
+      } else if (model()$network$baseline == "independent"){
+        return("unrelated")
+      } else {
+        return(model()$network$baseline)
+      }
+    })
+    
+    #The parameters to display in Gelman plots
+    parameters <- reactive({
+      if (package == "gemtc") {
+        return(model()$mtcResults$model$monitors$enabled)
+      } else if (package == "bnma") {
+        return(GetBnmaParameters(all_parameters = attr(model()$samples[[1]], "dimnames")[[2]],
+                                 effects_type = model()$network$type,
+                                 cov_parameters = cov_parameters()))
+      }
+    })
+    
+    #For baseline risk, create a Gelman plot for each parameter
+    gelman_plots <- reactive({
+      if (package == "gemtc") {
+        return(NULL)
+      } else if (package == "bnma") {
+        return(
+          lapply(parameters(),
+                 function(parameter){
+                   return(coda::gelman.plot(model()$samples[, parameter]))
+                 }
+          )
+        )
+      }
+    })
+    
+    #The number of rows, to determine the dimensions of the grid in bnma, and the height of the plot in bnma and gemtc
+    n_rows <- reactive({
+      ceiling(length(parameters()) / 2)
+    })
+    
+    # Gelman plots
+    output$gemtc_gelman <- renderPlot(
+      {
+        if (is.null(model_valid()) || !model_valid()) {
+          return()
+        }
+        if (package == "gemtc") {
+          return(gelman.plot(model()$mtcResults))
+        } else if (package == "bnma") {
+          par(mfrow = c(n_rows(), 2))
+          return(BnmaGelmanPlots(gelman_plots = gelman_plots(), parameters = parameters()))
+        }
+      },
+      height = function() {
+        n_rows() * 300
+      }
+    )
+    
+    #Trace plots
+    output$trace_plots <- renderPlot(
+      {
+        if (is.null(model_valid()) || !model_valid()) {
+          return()
+        }
+        
+        plotlist <- reactive(
+          if (package == "gemtc") {
+            return(TracePlots(model = model()$mtcResults, parameters = parameters()))
+          } else if (package == "bnma") {
+            return(TracePlots(model = model(), parameters = parameters()))
+          }
+        )
+        
+        return(
+          cowplot::plot_grid(
+            plotlist = plotlist(),
+            ncol = 2
+          )
+        )
+      },
+      height = function() {
+        n_rows() * 200
+      }
+    )
+    
+    #Posterior density plots
+    output$density_plots <- renderPlot(
+      {
+        if (is.null(model_valid()) || !model_valid()) {
+          return()
+        }
+        
+        plotlist <- reactive(
+          if (package == "gemtc") {
+            return(DensityPlots(model = model()$mtcResults, parameters = parameters()))
+          } else if (package == "bnma") {
+            return(DensityPlots(model = model(), parameters = parameters()))
+          }
+        )
+        
+        return(
+          cowplot::plot_grid(
+            plotlist = plotlist(),
+            ncol = 2
+          )
+        )
+      },
+      height = function() {
+        n_rows() * 200
+      }
+    )
+  })
+}

--- a/R/bayesian/result_details/result_details_panel.R
+++ b/R/bayesian/result_details/result_details_panel.R
@@ -12,11 +12,6 @@ result_details_panel_ui <- function(id, item_name) {
     shinycssloaders::withSpinner(
       verbatimTextOutput(outputId = ns("gemtc_results")),
       type = 6
-    ),
-    p(tags$strong(glue::glue("Gelman convergence assessment plot for {item_name}"))),
-    shinycssloaders::withSpinner(
-      plotOutput(outputId = ns("gemtc_gelman"), inline = TRUE),
-      type = 6
     )
   )
 }
@@ -45,65 +40,6 @@ result_details_panel_server <- function(id, model, model_valid, package = "gemtc
         return(summary(model()))
       }
     })
-    
-    #Need to use bnma terminology for covariate parameters below
-    cov_parameters <- reactive({
-      if (model()$network$baseline == "common"){
-        return("shared")
-      } else if (model()$network$baseline == "independent"){
-        return("unrelated")
-      } else {
-        return(model()$network$baseline)
-      }
-    })
-    
-    #The parameters to display in Gelman plots
-    parameters <- reactive({
-      if (package == "gemtc") {
-        return(model()$mtcResults$model$monitors$enabled)
-      } else if (package == "bnma") {
-        return(GetBnmaParameters(all_parameters = attr(model()$samples[[1]], "dimnames")[[2]],
-                                 effects_type = model()$network$type,
-                                 cov_parameters = cov_parameters()))
-      }
-    })
-    
-    #For baseline risk, create a Gelman plot for each parameter
-    gelman_plots <- reactive({
-      if (package == "gemtc") {
-        return(NULL)
-      } else if (package == "bnma") {
-        return(
-          lapply(parameters(),
-                 function(parameter){
-                   return(coda::gelman.plot(model()$samples[, parameter]))
-                 }
-          )
-        )
-      }
-    })
-    
-    #The number of rows, to determine the dimensions of the grid in bnma, and the height of the plot in bnma and gemtc
-    n_rows <- reactive({
-      ceiling(length(parameters()) / 2)
-    })
-    
-    # Gelman plots
-    output$gemtc_gelman <- renderPlot(
-      {
-        if (is.null(model_valid()) || !model_valid()) {
-          return()
-        }
-        if (package == "gemtc") {
-          return(gelman.plot(model()$mtcResults))
-        } else if (package == "bnma") {
-          par(mfrow = c(n_rows(), 2))
-          return(BnmaGelmanPlots(gelman_plots = gelman_plots(), parameters = parameters()))
-        }
-      },
-      height = function() {
-        n_rows() * 300
-      }
-    )
+
   })
 }

--- a/R/meta_regression/baseline_risk_analysis_panel.R
+++ b/R/meta_regression/baseline_risk_analysis_panel.R
@@ -44,8 +44,8 @@ baseline_risk_analysis_panel_ui <- function(id, page_numbering) {
         result_details_page_ui(id = ns("baseline_risk_result_details"), item_names = c("all studies"))
       ),
       tabPanel(
-        title = paste0(page_numbering$AddChild(), " Deviance report"),
-        deviance_report_page_ui(id = ns("baseline_risk_deviance_report"), item_names = c("all studies"))
+        title = paste0(page_numbering$AddChild(), " Diagnostics"),
+        diagnostics_page_ui(id = ns("baseline_risk_diagnostics"), item_names = c("all studies"), page_numbering)
       ),
       tabPanel(
         title = paste0(page_numbering$AddChild(), " Model details"),
@@ -243,7 +243,7 @@ baseline_risk_analysis_panel_server <- function(    id,
     result_details_page_server(id = "baseline_risk_result_details", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
     
     # 4b-7 Deviance report
-    deviance_report_page_server(id = "baseline_risk_deviance_report", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
+    diagnostics_page_server(id = "baseline_risk_diagnostics", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")
     
     # 4c-8 Model details
     model_details_panel_server(id = "baseline_risk_model_details", models = c(model_reactive), models_valid = c(model_valid), package = "bnma")

--- a/R/meta_regression/covariate_analysis_panel.R
+++ b/R/meta_regression/covariate_analysis_panel.R
@@ -93,8 +93,8 @@ covariate_analysis_panel_ui <- function(id, page_numbering) {
             result_details_page_ui(id = ns("result_details"), item_names = c("all studies"))
           ),
           tabPanel(
-            title = paste0(page_numbering$AddChild(), " Deviance report"),
-            deviance_report_page_ui(id = ns("deviance_report"), item_names = c("all studies"))
+            title = paste0(page_numbering$AddChild(), " Diagnostics"),
+            diagnostics_page_ui(id = ns("diagnostics"), item_names = c("all studies"), page_numbering)
           ),
           tabPanel(
             title = paste0(page_numbering$AddChild(), " Model details"),
@@ -308,7 +308,7 @@ covariate_analysis_panel_server <- function(
     result_details_page_server(id = "result_details", models = c(model_output), models_valid = c(model_valid))
     
     # 4c-7 Deviance report
-    deviance_report_page_server(id = "deviance_report", models = c(model_output), models_valid = c(model_valid))
+    diagnostics_page_server(id = "diagnostics", models = c(model_output), models_valid = c(model_valid))
     
     # 4c-8 Model details
     model_details_panel_server(id = "model_details", models = c(model_output), models_valid = c(model_valid))

--- a/R/plot.R
+++ b/R/plot.R
@@ -518,7 +518,7 @@ levplot <- function(model, package = "gemtc") {
 #' @param gelman_plot Output from coda::gelman.plot(bnma_model$samples[, parm]), where parm is a parameter from 'bnma_model'.
 #' @param parameter The parameter from the previous argument, used as the title.
 #' @return Reproduces the Gelman plot mentioned in @param gelman_plot as a plot that can be put in a grid.
-BnmaGelmanPlot <- function(gelman_plot, parameter){
+BnmaGelmanPlot <- function(gelman_plot, parameter) {
   y_vals_median <- gelman_plot$shrink[, , "median"]
   y_vals_975 <- gelman_plot$shrink[, , "97.5%"]
   x_vals <- gelman_plot$last.iter
@@ -536,8 +536,36 @@ BnmaGelmanPlot <- function(gelman_plot, parameter){
 #' @param gelman_plots List of outputs from coda::gelman.plot(bnma_model$samples[, parm]), where parm is a parameter from bnma_model.
 #' @param parameters Vector of parameters mentioned in the previous argument.
 #' @return Plots the Gelman plots mentioned in @param gelman_plots.
-BnmaGelmanPlots <- function(gelman_plots, parameters){
+BnmaGelmanPlots <- function(gelman_plots, parameters) {
   for (i in 1:length(parameters)) {
     BnmaGelmanPlot(gelman_plot = gelman_plots[[i]], parameter = parameters[i])
   }
+}
+
+
+#' Creates trace plots of MCMC samples.
+#' 
+#' @param model Model output. 
+#' @param parameters Vector of parameters to create trace plots for.
+#' @return List of ggplot trace plots.
+TracePlots <- function(model, parameters) {
+  trace_plots <- list()
+  for (i in 1:length(parameters)) {
+    trace_plots[[i]] <- bayesplot::mcmc_trace(x = model$samples, pars = parameters[i]) + ggplot2::ggtitle(parameters[i]) + ggplot2::theme(plot.title = element_text(hjust = 0.5))
+  }
+  return(trace_plots)
+}
+
+
+#' Creates posterior density plots of MCMC samples.
+#' 
+#' @param model Model output. 
+#' @param parameters Vector of parameters to create density plots for.
+#' @return List of ggplot density plots.
+DensityPlots <- function(model, parameters) {
+  density_plots <- list()
+  for (i in 1:length(parameters)) {
+    density_plots[[i]] <- bayesplot::mcmc_hist(x = model$samples, pars = parameters[i])
+  }
+  return(density_plots)
 }

--- a/R/plot.R
+++ b/R/plot.R
@@ -513,12 +513,12 @@ levplot <- function(model, package = "gemtc") {
 }
 
 
-#' Creates a Gelman plot for a BNMA baseline-risk model.
+#' Creates a Gelman plot for a gemtc or bnma model.
 #' 
-#' @param gelman_plot Output from coda::gelman.plot(bnma_model$samples[, parm]), where parm is a parameter from 'bnma_model'.
+#' @param gelman_plot Output from coda::gelman.plot(model$samples[, parm]), where parm is a parameter from the model.
 #' @param parameter The parameter from the previous argument, used as the title.
 #' @return Reproduces the Gelman plot mentioned in @param gelman_plot as a plot that can be put in a grid.
-BnmaGelmanPlot <- function(gelman_plot, parameter) {
+GelmanPlot <- function(gelman_plot, parameter) {
   y_vals_median <- gelman_plot$shrink[, , "median"]
   y_vals_975 <- gelman_plot$shrink[, , "97.5%"]
   x_vals <- gelman_plot$last.iter
@@ -531,14 +531,14 @@ BnmaGelmanPlot <- function(gelman_plot, parameter) {
 }
 
 
-#' Creates Gelman plots for a BNMA baseline-risk model.
+#' Creates Gelman plots for a gemtc or bnma model.
 #' 
-#' @param gelman_plots List of outputs from coda::gelman.plot(bnma_model$samples[, parm]), where parm is a parameter from bnma_model.
+#' @param gelman_plots List of outputs from coda::gelman.plot(model$samples[, parm]), where parm is a parameter from the model.
 #' @param parameters Vector of parameters mentioned in the previous argument.
 #' @return Plots the Gelman plots mentioned in @param gelman_plots.
-BnmaGelmanPlots <- function(gelman_plots, parameters) {
+GelmanPlots <- function(gelman_plots, parameters) {
   for (i in 1:length(parameters)) {
-    BnmaGelmanPlot(gelman_plot = gelman_plots[[i]], parameter = parameters[i])
+    GelmanPlot(gelman_plot = gelman_plots[[i]], parameter = parameters[i])
   }
 }
 


### PR DESCRIPTION
I couldn't get `MCMCvis::MCMCtrace()` to work, so I used `bayesplot::mcmc_trace()` and `bayesplot::mcmc_hist()` instead. They return a ggplot so the code to arrange them is different to the Gelman plots.

There are a couple of things I'm not happy with:

- The plots don't use the full width of the screen in the regression models. The same is true for NMA but that's fine because the sensitivity model takes up half the screen.
- They take a long time to run. These plots are actually simple to make, so at some point in the near future I'd like to draw them manually and see if they run any faster.

Since we're on a deadline to resubmit the paper (28th April, seven working days) I do not want to address either of the above in this task.