### PR TITLE
Mi 96 add bayesian details

### DIFF
--- a/R/data/data_wrangling.R
+++ b/R/data/data_wrangling.R
@@ -544,3 +544,18 @@ FindMaxArms <- function(data) {
     )
   }
 }
+
+
+
+#' Returns a number rounded in a nice manner.
+#' 
+#' @param variance Any number, doesn't have to be a variance.
+#' @return 'variance' with 1 decimal place or 1 significant figure.
+RoundVariance <- function(variance) {
+  rounded <- round(variance, digits = 1)
+  if (rounded == 0) {
+    return(signif(variance, digits = 1))
+  } else {
+    return(rounded)
+  }
+}

--- a/R/meta_regression/bnma_analysis.R
+++ b/R/meta_regression/bnma_analysis.R
@@ -225,8 +225,8 @@ BnmaRelativeEffects <- function(model, covariate_value) {
   centred_covariate_value <- covariate_value - model$network$mx_bl
   
   samples <- list()
-  #The number of chains is always left at the default 3
-  for (chain in 1:3) {
+  #The number of chains is always set to 4
+  for (chain in 1:4) {
     samples[[chain]] <- model$samples[[chain]][, treatment_parameters] + centred_covariate_value * model$samples[[chain]][, covariate_parameters]
   }
   
@@ -532,53 +532,53 @@ GetBnmaMcmcCharacteristics <- function(model) {
 #' @param model BNMA model output.
 #' @return Data frame with prior distribution information.
 GetBnmaPriors <- function(model) {
-  treatment_effect_mean <- reactive(model$network$prior.data$mean.d)
-  treatment_effect_var <- reactive(round(1 / model$network$prior.data$prec.d, digits = 1))
-  eta_mean <- reactive(model$network$prior.data$mean.Eta)
-  eta_var <- reactive(round(1 / model$network$prior.data$prec.Eta, digits = 1))
+  treatment_effect_mean <- model$network$prior.data$mean.d
+  treatment_effect_var <- round(1 / model$network$prior.data$prec.d, digits = 1)
+  eta_mean <- model$network$prior.data$mean.Eta
+  eta_var <- round(1 / model$network$prior.data$prec.Eta, digits = 1)
   prior_table <- data.frame(parameter = c("Relative treatment effects",
                                           "Intercepts"),
-                            value = c(paste0(" ~ N (", treatment_effect_mean(), ", ", treatment_effect_var(), ")"),
-                                      paste0(" ~ N (", eta_mean(), ", ", eta_var(), ")"))
+                            value = c(paste0(" ~ N (", treatment_effect_mean, ", ", treatment_effect_var, ")"),
+                                      paste0(" ~ N (", eta_mean, ", ", eta_var, ")"))
   )
   
   #If the model is random effects, add the heterogenity SD
   if (model$network$type == "random") {
-    heterogeneity_sd_lower <- reactive(round(model$network$prior.data$hy.prior.1, digits = 1))
-    heterogeneity_sd_upper <- reactive(round(model$network$prior.data$hy.prior.2, digits = 1))
+    heterogeneity_sd_lower <- round(model$network$prior.data$hy.prior.1, digits = 1)
+    heterogeneity_sd_upper <- round(model$network$prior.data$hy.prior.2, digits = 1)
     prior_table <- rbind(prior_table,
                          data.frame(parameter = "Heterogeneity standard deviation",
-                                    value = paste0(" ~ Unif (", heterogeneity_sd_lower(), ", ", heterogeneity_sd_upper(), ")"))
+                                    value = paste0(" ~ Unif (", heterogeneity_sd_lower, ", ", heterogeneity_sd_upper, ")"))
     )
   }
   
   #If the model is NMR shared, add the covariate parameter
   if (model$network$baseline == "common") {
-    shared_mean <- reactive(model$network$prior.data$mean.bl)
-    shared_var <- reactive(round(1 / model$network$prior.data$prec.bl, digits = 1))
+    shared_mean <- model$network$prior.data$mean.bl
+    shared_var <- round(1 / model$network$prior.data$prec.bl, digits = 1)
     prior_table <- rbind(prior_table,
                          data.frame(parameter = "Shared covariate parameter",
-                                    value = paste0(" ~ N (", shared_mean(), ", ", shared_var(), ")"))
+                                    value = paste0(" ~ N (", shared_mean, ", ", shared_var, ")"))
     )
     #If the model is NMR exchangeable, add the covariate mean and variance parameters
   } else if (model$network$baseline == "exchangeable") {
-    exchangeable_mean_mean <- reactive(model$network$prior.data$mean.bl)
-    exchangeable_mean_var <- reactive(round(1 / model$network$prior.data$prec.bl, digits = 1))
-    exchangeable_sd_lower <- reactive(model$network$prior.data$hy.prior.bl.1)
-    exchangeable_sd_upper <- reactive(model$network$prior.data$hy.prior.bl.2)
+    exchangeable_mean_mean <- model$network$prior.data$mean.bl
+    exchangeable_mean_var <- round(1 / model$network$prior.data$prec.bl, digits = 1)
+    exchangeable_sd_lower <- model$network$prior.data$hy.prior.bl.1
+    exchangeable_sd_upper <- model$network$prior.data$hy.prior.bl.2
     prior_table <- rbind(prior_table,
                          data.frame(parameter = c("Covariate mean",
                                                   "Covariate standard deviation"),
-                                    value = c(paste0(" ~ N (", exchangeable_mean_mean(), ", ", exchangeable_mean_var(), ")"),
-                                              paste0(" ~ Unif (", exchangeable_sd_lower(), ", ", exchangeable_sd_upper(), ")")))
+                                    value = c(paste0(" ~ N (", exchangeable_mean_mean, ", ", exchangeable_mean_var, ")"),
+                                              paste0(" ~ Unif (", exchangeable_sd_lower, ", ", exchangeable_sd_upper, ")")))
     )
     #If the model is NMR unrelated, add the covariate parameters
   } else if (model$network$baseline == "independent") {
-    unrelated_mean <- reactive(model$network$prior.data$mean.bl)
-    unrelated_var <- reactive(round(1 / model$network$prior.data$prec.bl, digits = 1))
+    unrelated_mean <- model$network$prior.data$mean.bl
+    unrelated_var <- round(1 / model$network$prior.data$prec.bl, digits = 1)
     prior_table <- rbind(prior_table,
                          data.frame(parameter = "Covariate parameters",
-                                    value = paste0(" ~ N (", unrelated_mean(), ", ", unrelated_var(), ")"))
+                                    value = paste0(" ~ N (", unrelated_mean, ", ", unrelated_var, ")"))
     )
   }
   return(prior_table)

--- a/R/meta_regression/gemtc_analysis.R
+++ b/R/meta_regression/gemtc_analysis.R
@@ -349,3 +349,71 @@ CalculateCredibleRegions <- function(model_output) {
   rel_eff_summary <- summary(rel_eff)
   return(rel_eff_summary$summaries$quantiles[parameter_name, c("2.5%", "97.5%")])
 }
+
+#' MCMC characteristics from a GEMTC model.
+#' 
+#' @param model GEMTC model output.
+#' @return Data frame with four MCMC characteristics.
+GetGemtcMcmcCharacteristics <- function(model) {
+  return(data.frame(characteristic = c("Chains",
+                                       "Burn-in iterations",
+                                       "Sample iterations",
+                                       "Thinning factor"),
+                    value = c(model$model$n.chain,
+                              attr(model$samples[[1]], "mcpar")[1] - 1,
+                              length(model$samples[[1]][, 1]),
+                              summary(model)$summaries$thin)
+                    )
+         )
+}
+
+#' Prior distributions from a GEMTC model.
+#' 
+#' @param model GEMTC model output.
+#' @return Data frame with prior distribution information.
+GetGemtcPriors <- function(model) {
+  treatment_effect_var <- reactive(round(model$model$data$re.prior.sd^2, digits = 1))
+  prior_table <- data.frame(parameter = c("Relative treatment effects",
+                                          "Intercepts"),
+                            value = c(paste0(" ~ N (0, ", treatment_effect_var(), ")"),
+                                      paste0(" ~ N (0, ", treatment_effect_var(), ")"))
+  )
+  
+  #If the model is random effects, add the heterogenity SD
+  if (model$model$linearModel == "random") {
+    heterogeneity_sd_upper <- reactive(round(model$model$data$om.scale, digits = 1))
+    prior_table <- rbind(prior_table,
+                         data.frame(parameter = "Heterogeneity standard deviation",
+                                    value = paste0(" ~ Unif (0, ", heterogeneity_sd_upper(), ")"))
+    )
+  }
+  
+  if (!is.null(model$model$regressor$coefficient)) {
+    #If the model is NMR shared, add the covariate parameter
+    if (model$model$regressor$coefficient == "shared") {
+      shared_var <- reactive(round(model$model$data$om.scale^2, digits = 1))
+      prior_table <- rbind(prior_table,
+                           data.frame(parameter = "Shared covariate parameter",
+                                      value = paste0(" ~ Scaled t-distribution (0, ", shared_var(), ", 1)"))
+      )
+      #If the model is NMR exchangeable, add the covariate mean and variance parameters
+    } else if (model$model$regressor$coefficient == "exchangeable") {
+      exchangeable_mean_var <- reactive(round(model$model$data$om.scale^2, digits = 1))
+      exchangeable_sd_upper <- reactive(round(model$model$data$om.scale, digits = 1))
+      prior_table <- rbind(prior_table,
+                           data.frame(parameter = c("Covariate mean",
+                                                    "Covariate standard deviation"),
+                                      value = c(paste0(" ~ Scaled t-distribution (0, ", exchangeable_mean_var(), ", 1)"),
+                                                paste0(" ~ Unif (0, ", exchangeable_sd_upper(), ")")))
+      )
+      #If the model is NMR unrelated, add the covariate parameters
+    } else if (model$model$regressor$coefficient == "unrelated") {
+      unrelated_var <- reactive(round(model$model$data$om.scale^2, digits = 1))
+      prior_table <- rbind(prior_table,
+                           data.frame(parameter = "Covariate parameters",
+                                      value = paste0(" ~ Scaled t-distribution (0, ", unrelated_var(), ", 1)"))
+      )
+    }
+  }
+  return(prior_table)
+}

--- a/R/meta_regression/gemtc_analysis.R
+++ b/R/meta_regression/gemtc_analysis.R
@@ -372,46 +372,46 @@ GetGemtcMcmcCharacteristics <- function(model) {
 #' @param model GEMTC model output.
 #' @return Data frame with prior distribution information.
 GetGemtcPriors <- function(model) {
-  treatment_effect_var <- reactive(round(model$model$data$re.prior.sd^2, digits = 1))
+  treatment_effect_var <- round(model$model$data$re.prior.sd^2, digits = 1)
   prior_table <- data.frame(parameter = c("Relative treatment effects",
                                           "Intercepts"),
-                            value = c(paste0(" ~ N (0, ", treatment_effect_var(), ")"),
-                                      paste0(" ~ N (0, ", treatment_effect_var(), ")"))
+                            value = c(paste0(" ~ N (0, ", treatment_effect_var, ")"),
+                                      paste0(" ~ N (0, ", treatment_effect_var, ")"))
   )
   
   #If the model is random effects, add the heterogenity SD
   if (model$model$linearModel == "random") {
-    heterogeneity_sd_upper <- reactive(round(model$model$data$om.scale, digits = 1))
+    heterogeneity_sd_upper <- round(model$model$data$om.scale, digits = 1)
     prior_table <- rbind(prior_table,
                          data.frame(parameter = "Heterogeneity standard deviation",
-                                    value = paste0(" ~ Unif (0, ", heterogeneity_sd_upper(), ")"))
+                                    value = paste0(" ~ Unif (0, ", heterogeneity_sd_upper, ")"))
     )
   }
   
   if (!is.null(model$model$regressor$coefficient)) {
     #If the model is NMR shared, add the covariate parameter
     if (model$model$regressor$coefficient == "shared") {
-      shared_var <- reactive(round(model$model$data$om.scale^2, digits = 1))
+      shared_var <- RoundVariance(model$model$data$om.scale^2)
       prior_table <- rbind(prior_table,
                            data.frame(parameter = "Shared covariate parameter",
-                                      value = paste0(" ~ Scaled t-distribution (0, ", shared_var(), ", 1)"))
+                                      value = paste0(" ~ Scaled t-distribution (0, ", shared_var, ", 1)"))
       )
       #If the model is NMR exchangeable, add the covariate mean and variance parameters
     } else if (model$model$regressor$coefficient == "exchangeable") {
-      exchangeable_mean_var <- reactive(round(model$model$data$om.scale^2, digits = 1))
-      exchangeable_sd_upper <- reactive(round(model$model$data$om.scale, digits = 1))
+      exchangeable_mean_var <- round(model$model$data$om.scale^2, digits = 1)
+      exchangeable_sd_upper <- round(model$model$data$om.scale, digits = 1)
       prior_table <- rbind(prior_table,
                            data.frame(parameter = c("Covariate mean",
                                                     "Covariate standard deviation"),
-                                      value = c(paste0(" ~ Scaled t-distribution (0, ", exchangeable_mean_var(), ", 1)"),
-                                                paste0(" ~ Unif (0, ", exchangeable_sd_upper(), ")")))
+                                      value = c(paste0(" ~ Scaled t-distribution (0, ", exchangeable_mean_var, ", 1)"),
+                                                paste0(" ~ Unif (0, ", exchangeable_sd_upper, ")")))
       )
       #If the model is NMR unrelated, add the covariate parameters
     } else if (model$model$regressor$coefficient == "unrelated") {
-      unrelated_var <- reactive(round(model$model$data$om.scale^2, digits = 1))
+      unrelated_var <- RoundVariance(model$model$data$om.scale^2)
       prior_table <- rbind(prior_table,
                            data.frame(parameter = "Covariate parameters",
-                                      value = paste0(" ~ Scaled t-distribution (0, ", unrelated_var(), ", 1)"))
+                                      value = paste0(" ~ Scaled t-distribution (0, ", unrelated_var, ", 1)"))
       )
     }
   }

--- a/tests/testthat/test-bnma_analysis.R
+++ b/tests/testthat/test-bnma_analysis.R
@@ -216,7 +216,9 @@ test_that("1. BaselineRiskRegression() sets RNGs correctly;
            2. BaselineRiskRegression() gives reproducible output;
            3. BaselineRiskModelOutput() gives correct output;
            4. BnmaRelativeEffects() calculates relative effects;
-           5. GetReferenceOutcome() obtains imputed outcomes;", {
+           5. GetReferenceOutcome() obtains imputed outcomes;
+           6. GetBnmaMcmcCharacteristics() returns correct MCMC data;
+           7. GetBnmaPriors() returns correct prior distributions.", {
   
   data <- list(ArmLevel = data.frame(
     Study = c(rep("Constantine", 3), rep("Leo", 3), rep("Justinian", 2)),
@@ -344,7 +346,31 @@ test_that("1. BaselineRiskRegression() sets RNGs correctly;
   
   #Unit test 5  
   expect_equal(GetReferenceOutcome(data$ArmLevel, treatment_ids, outcome_type, observed, result_1), expected_reference_outcome)
+  #-------------------------------------------------------------------
   
+  expected_mcmc_table <- data.frame(characteristic = c("Chains",
+                                                       "Burn-in iterations",
+                                                       "Sample iterations",
+                                                       "Thinning factor"),
+                                    value = c(4, 5000, 20000, 1))
+  
+  #Unit test 6
+  expect_equal(GetBnmaMcmcCharacteristics(result_1), expected_mcmc_table)
+  #-------------------------------------------------------------------
+  
+  expected_priors_table <- data.frame(parameter = c("Relative treatment effects",
+                                                    "Intercepts",
+                                                    "Heterogeneity standard deviation",
+                                                    "Covariate mean",
+                                                    "Covariate standard deviation"),
+                                      value = c(" ~ N (0, 10000)",
+                                                " ~ N (0, 10000)",
+                                                " ~ Unif (0, 100)",
+                                                " ~ N (0, 10000)",
+                                                " ~ Unif (0, 100)")
+                                      )
+  #Unit test 7
+  expect_equal(GetBnmaPriors(result_1), expected_priors_table)
 })
 
 

--- a/tests/testthat/test-data_wrangling.R
+++ b/tests/testthat/test-data_wrangling.R
@@ -1344,3 +1344,9 @@ test_that("FindMaxArms() returns the correct number of arms for wide data", {
   data <- read.csv("data\\Cont_wide.csv")
   expect_equal(FindMaxArms(data), 3)
 })
+
+
+test_that("RoundVariance() rounds correctly", {
+  expect_equal(RoundVariance(1234.5678), 1234.6)
+  expect_equal(RoundVariance(0.000789), 0.0008)
+})

--- a/tests/testthat/test-gemtc_analysis.R
+++ b/tests/testthat/test-gemtc_analysis.R
@@ -167,7 +167,10 @@ test_that("CreateGemtcModel() has correct model settings for MD outcome", {
 
 })
 
-test_that("RunCovariateModel() gives reproducible output. Follow on: FindCovariateDefault() & CovariateModelOutput() gives correct output", {
+test_that("RunCovariateModel() gives reproducible output.
+          FindCovariateDefault() gives correct output.
+          CovariateModelOutput() gives correct output.
+          GetGemtcMcmcCharacteristics() returns correct MCMC data.", {
   reference = "the_Little"
 
   data <- read.csv("data/Binary_wide_continuous_cov.csv")
@@ -209,6 +212,14 @@ test_that("RunCovariateModel() gives reproducible output. Follow on: FindCovaria
   expect_equal(output_1$covariate_value, covariate_value)
   expect_equal(output_1$reference_name, reference)
   expect_equal(output_1$comparator_names, c("the_Butcher", "the_Dung_named", "the_Great", "the_Slit_nosed", "the_Younger"))
+  
+  expected_mcmc_table <- data.frame(characteristic = c("Chains",
+                                                       "Burn-in iterations",
+                                                       "Sample iterations",
+                                                       "Thinning factor"),
+                                    value = c(4, 5000, 20000, 1))
+  
+  expect_equal(GetGemtcMcmcCharacteristics(result_1), expected_mcmc_table)
 })
 
 test_that("CalculateCredibleRegions() gives nothing for NA evidence range", {


### PR DESCRIPTION
I've added download buttons, which wasn't on Jira.
I have not done a test for the prior distributions in gemtc, because the values are reactive to the data and I don't know how they are chosen.
The same might actually be true of bnma, so perhaps that test isn't worth much.

It was tricky to work out the prior distributions. You have to look at the model code and then extract the relevant values from the data. For example, in gemtc the relative treatment effects have distribution `dnorm(0, prior.prec)`. prior.prec is defined by `prior.prec <- pow(re.prior.sd, -2)`, and `re.prior.sd` is not defined in the code, which means it's a value passed to JAGS. Once `re.prior.sd` was extracted from the model, I put the Normal distribution in its usual form, which is N(mean, variance). For some reason in Bayesian programs they use N(mean, precision) instead, where precision = 1/variance. In this case the variance is `re.prior.sd^2`.
When we first started meta-regression I did a comparison of prior distributions between gemtc and bnma, which was immensely helpful for this task. It's attached in case it helps you.

Since this is quite statsy, you could just review the rest of the code and we could find someone else to check the priors, if you're not happy doing it.