### PR TITLE
Deploy v7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,8 @@ jobs:
           install.packages("remotes")
           remotes::install_github("CRSU-Apps/MetaInsight", ref = Sys.getenv("current_sha"))
         shell: Rscript {0}
+        env: 
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # Deploy using rsconnect
       - name: Deploy
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,16 +51,23 @@ jobs:
       # Setup R (latest version)
       - uses: r-lib/actions/setup-r@v2
       # Get the branch name
-      - name: Get branch name
-        id: branch-names
-        uses: tj-actions/branch-names@v9.0.2
+      - name: Get sha
+        env:
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          # If the workflow was triggered by a pull request, use the head sha of the pull request, otherwise use the sha of the commit that triggered the workflow
+          COMMIT_SHA="${PR_SHA:-$GITHUB_SHA}"
+          # Get the short sha (first 7 characters) and store it in environment variables
+          SHORT_SHA=$(echo $COMMIT_SHA | cut -c1-7)
+          echo "current_sha=$SHORT_SHA" >> $GITHUB_ENV
       # Install MetaInsight
       - name: Install MetaInsight
         run: |
-          cat("Installing MetaInsight from branch: ", "${{ steps.branch-names.outputs.current_branch }}", "\n")
+          cat("Installing MetaInsight from sha: ", Sys.getenv("current_sha"), "\n")
           install.packages("remotes")
-          remotes::install_github("crsu/MetaInsight", ref = "${{ steps.branch-names.outputs.current_branch }}")
-        shell : Rscript {0}
+          remotes::install_github("CRSU-Apps/MetaInsight", ref = "Sys.getenv('current_sha')")
+        shell: Rscript {0}
       # Deploy using rsconnect
       - name: Deploy
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           cat("Installing MetaInsight from branch: ", "${{ steps.branch-names.outputs.current_branch }}", "\n")
           install.packages("remotes")
-          remotes::install_github("crsu/MetaInsight", ref = ${{ steps.branch-names.outputs.current_branch }})
+          remotes::install_github("crsu/MetaInsight", ref = "${{ steps.branch-names.outputs.current_branch }}")
         shell : Rscript {0}
       # Deploy using rsconnect
       - name: Deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     name: Deploy to shinyapps
     # allow skipping deployment for commits containing '[automated]' or '[no-deploy]' in the commit message
     if: "!contains(github.event.head_commit.message, '[automated]') && !contains(github.event.head_commit.message, '[no-deploy]')"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set deployment type
         run: |
@@ -35,9 +35,9 @@ jobs:
           fi
           # Store the appName in environment variables based on deployment type
           if [[ $DEPLOY_TYPE = "test" ]]; then
-            echo "appName=MetaInsight_test" >> $GITHUB_ENV
+            echo "appName=MetaInsight_Scholar_test" >> $GITHUB_ENV
           else
-            echo "appName=MetaInsight" >> $GITHUB_ENV
+            echo "appName=MetaInsight_Scholar" >> $GITHUB_ENV
           fi
       - name: Print deployment type
         run: |
@@ -47,13 +47,20 @@ jobs:
           sudo apt update
           sudo apt install libcurl4-openssl-dev jags libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libglpk-dev libmagick++-dev -y
       # Checkout the repo
-      - uses: actions/checkout@v4
-      # Setup R (4.3.2)
+      - uses: actions/checkout@v6
+      # Setup R (latest version)
       - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: '4.4.2'
-      # Setup and install dependencies using renv
-      - uses: r-lib/actions/setup-renv@v2
+      # Get the branch name
+      - name: Get branch name
+        id: branch-names
+        uses: tj-actions/branch-names@v9.0.2
+      # Install MetaInsight
+      - name: Install MetaInsight
+        run: |
+          cat("Installing MetaInsight from branch: ", "${{ steps.branch-names.outputs.current_branch }}", "\n")
+          install.packages("remotes")
+          remotes::install_github("crsu/MetaInsight", ref = ${{ steps.branch-names.outputs.current_branch }})
+        shell : Rscript {0}
       # Deploy using rsconnect
       - name: Deploy
         run: |
@@ -70,6 +77,7 @@ jobs:
           cat(paste0("Deploying ", Sys.getenv("appName"), "\n"))
           # Deploy application
           rsconnect::deployApp(
+            "./inst/shiny/",
             appName = Sys.getenv("appName"),
             account = Sys.getenv("accountName"),
             forceUpdate = TRUE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           cat("Installing MetaInsight from sha: ", Sys.getenv("current_sha"), "\n")
           install.packages("remotes")
-          remotes::install_github("CRSU-Apps/MetaInsight", ref = "Sys.getenv('current_sha')")
+          remotes::install_github("CRSU-Apps/MetaInsight", ref = Sys.getenv("current_sha"))
         shell: Rscript {0}
       # Deploy using rsconnect
       - name: Deploy


### PR DESCRIPTION
Fixes deploy functionality to the new scholorised version of MetaInsight. 

**Note** that this will only deploy to [https://crsu.shinyapps.io/MetaInsight_Scholar](https://crsu.shinyapps.io/MetaInsight_Scholar) or [https://crsu.shinyapps.io/MetaInsight_Scholar_test](https://crsu.shinyapps.io/MetaInsight_Scholar_test), and will need to be changed following discussion of if and when we replace version 6.4.2 with 7.0.1 at [https://crsu.shinyapps.io/MetaInsight](https://crsu.shinyapps.io/MetaInsight)